### PR TITLE
Add comprehensive characterization test suite and fix import bugs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+# Run the characterization test suite on every push and pull request so the
+# safety net guards the upcoming modernization/refactor work.
+on:
+  push:
+    branches: ["main", "claude/**"]
+  pull_request:
+    branches: ["main"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Tests (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install package and test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install pytest pytest-cov
+
+      - name: Run test suite with coverage
+        run: |
+          pytest tests/ -ra --cov=fiberis --cov-report=term-missing --cov-report=xml

--- a/docs/modernization_notes.md
+++ b/docs/modernization_notes.md
@@ -1,0 +1,97 @@
+# fibeRIS Modernization Notes
+
+This document tracks the modernization effort for `fibeRIS`. The strategy is
+**safety net first, refactor second**: build a comprehensive characterization
+(golden-master) test suite that pins the *current* observable behavior, then
+refactor and upgrade dependencies under its protection.
+
+## Phase 1 — Test safety net (DONE)
+
+A characterization suite was added across the whole package. Tests capture the
+behavior the code *currently* exhibits (obtained by running the code, not by
+guessing), so any behavior-preserving refactor keeps them green, while a fix to
+one of the bugs below flips a specifically-marked test red on purpose.
+
+- **Suite size:** 770 passing, 13 skipped (skips require unbundled vendor data).
+- **Coverage:** ~70% of the package (branch coverage enabled), up from a near-zero
+  baseline on most modules.
+- **Tooling:** activated `pytest` / `coverage` / `mypy` config in `pyproject.toml`,
+  added `tests/conftest.py` (shared fixtures, headless matplotlib), and a GitHub
+  Actions CI workflow running the suite on Python 3.10–3.12.
+
+Per-area coverage highlights: `analyzer` core classes 83–99%, `utils` 74–100%,
+`simulator` 75%, `moose` config/editor 100% and `model_builder` 71%, `io/core`
+92%.
+
+## Bugs / quirks pinned by the suite (Phase 2 backlog)
+
+These were discovered while writing characterization tests. Each is currently
+pinned as "expected" behavior with a `# NOTE: possible bug` marker in the tests;
+fixing them in Phase 2 means updating the corresponding test to assert the
+corrected behavior.
+
+### High priority — code that cannot run
+
+1. **`TensorProcessor/coreT1D.py` is unimportable.** Uses `Tuple[...]`
+   annotations but never imports `Tuple` (only `Optional, Union, List, Any,
+   Dict`). `import` raises `NameError` at class-definition time, so `Tensor1D`
+   can never be instantiated.
+2. **`io/reader_mariner_3d.py` fails to import** — missing `DataG3D`.
+3. **`io/reader_mariner_gauge1d.py` fails to import** — missing `Data1DGauge`
+   from `fiberis.analyzer`.
+4. **`io/reader_mariner_rfs_abandoned.py` (`Mariner2DRFS2D`)** does not implement
+   the abstract `to_analyzer`, so it cannot be instantiated (`TypeError`).
+
+### Medium priority — incorrect results
+
+5. **`Tensor2D.rotate_tensor` computes `R·T·R` instead of `R·T·Rᵀ`.** The einsum
+   passes `R.T` under the wrong subscript; rotating `[[1,0],[0,0]]` by 90° yields
+   `[[0,0],[0,-1]]` instead of the correct `[[0,0],[0,1]]`. (`CoreTensor.rotate_tensor`
+   does it correctly — they should be unified.)
+6. **`postprocessor.py` exclusion regex `r'.*?_\\d+\.csv$'`** has a doubled
+   backslash, so `\d` is treated literally and never matches. Numbered
+   vector-sampler files (`*_0000.csv`) are not excluded and get mis-loaded as
+   point samplers.
+7. **`Neumann` sign-convention mismatch** between `simulator/core/bcs.py`
+   (`BoundaryCondition.apply`: diag +1 / neighbour −1) and
+   `simulator/solver/matbuilder.py` (inline: diag −1 / neighbour +1). Only the
+   matbuilder path is live; `BoundaryCondition` is currently unused by the solver.
+
+### Lower priority — robustness / API consistency
+
+8. **`Data1DPumpingCurve.get_start_time` / `get_end_time` ignore their
+   `threshold` kwarg** (hard-coded indices), and `get_end_time` diverges from the
+   base class signature (`usedatetime` vs `use_timestamp`, different return type).
+9. **`get_value_by_time` on a single-point series** returns that point's value for
+   any query time (no real interpolation/extrapolation), contrary to the docstring.
+10. **`Data1DGauge.calculate_pressure_dropdown`** is an unimplemented stub that
+    always returns `0`.
+11. **`Data3D.load_npz` stringifies `name`/`variable_name`** with `str(...)`, so a
+    `None` round-trips as the literal string `'None'`.
+12. **`Tensor2D.set_data` / `Data2D.__copy__` share the input array by reference**
+    (no defensive copy), unlike their `CoreTensor` / `.copy()` counterparts.
+13. **`PostprocessorConfig` mutates the caller's `params` dict in place** (`.pop`),
+    and `PostprocessorConfigBase` uses a mutable default argument.
+14. **`build_mesh_for_casing_model` + `generate_input_file`** both call
+    `_finalize_mesh_block_renaming()`, appending a duplicate `RenameBlockGenerator`.
+15. `signal_utils` helpers with quirky edge-case conventions: `correlation_coefficient`
+    returns numbers (not NaN) for degenerate inputs; `xcor_match` is annotated
+    "TEST FAILED. DO NOT USE IT" in-source; `timeshift_xcor` sign convention is
+    documented as uncertain.
+
+## Phase 2 — Architecture modernization (proposed, not started)
+
+Under the protection of the suite:
+
+- Fix the high/medium-priority defects above (each has a pinned test ready to flip).
+- Reduce duplication across the `core<Dim>` classes (shared base for history,
+  npz I/O, naming, info/str, copy) — the philosophy doc already calls for this.
+- Modernize type hints (`Optional`/`Union`/`List` → `X | Y` and builtin generics,
+  `from __future__ import annotations`).
+- Replace `black` + `flake8` with `ruff`; wire `ruff` + `mypy` into CI.
+
+## Phase 3 — Dependency / Python upgrade (proposed, not started)
+
+- Raise `requires-python` to `>=3.10`.
+- Open up `numpy>=2.0` and `pandas` upper bounds, validating against the suite
+  (CI matrix already spans 3.10–3.12).

--- a/docs/modernization_notes.md
+++ b/docs/modernization_notes.md
@@ -32,15 +32,18 @@ corrected behavior.
 
 ### High priority — code that cannot run
 
-1. **`TensorProcessor/coreT1D.py` is unimportable.** Uses `Tuple[...]`
-   annotations but never imports `Tuple` (only `Optional, Union, List, Any,
-   Dict`). `import` raises `NameError` at class-definition time, so `Tensor1D`
-   can never be instantiated.
-2. **`io/reader_mariner_3d.py` fails to import** — missing `DataG3D`.
-3. **`io/reader_mariner_gauge1d.py` fails to import** — missing `Data1DGauge`
-   from `fiberis.analyzer`.
+1. ~~**`TensorProcessor/coreT1D.py` is unimportable.**~~ **FIXED.** Used
+   `Tuple[...]` annotations without importing `Tuple`; added it to the `typing`
+   import. `Tensor1D` now imports/instantiates and has full characterization tests.
+2. ~~**`io/reader_mariner_3d.py` fails to import.**~~ **FIXED.** Imported the
+   `DataG3D` *class* as if it were a module; corrected to
+   `from fiberis.analyzer.Geometry3D.coreG3D import DataG3D`.
+3. ~~**`io/reader_mariner_gauge1d.py` fails to import.**~~ **FIXED.** Imported the
+   `Data1DGauge` *class* as if it were a submodule; corrected to
+   `from fiberis.analyzer.Data1D.Data1D_Gauge import Data1DGauge`.
 4. **`io/reader_mariner_rfs_abandoned.py` (`Mariner2DRFS2D`)** does not implement
    the abstract `to_analyzer`, so it cannot be instantiated (`TypeError`).
+   Left as-is — the filename marks it intentionally abandoned.
 
 ### Medium priority — incorrect results
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,23 +87,26 @@ where = ["src"]
 # You can also explicitly list packsages if preferred over find:
 # packages = ["fiberis"]
 
-# Example: Configuration for Black code formatter
-# [tool.black]
-# line-length = 88
-# target-version = ['py39', 'py310', 'py311', 'py312']
+[tool.pytest.ini_options]
+minversion = "7.0"
+addopts = "-ra"
+testpaths = ["tests"]
+filterwarnings = [
+    # Surface deprecations from our own code while keeping third-party noise quiet.
+    "ignore::DeprecationWarning:matplotlib.*",
+]
 
-# Example: Configuration for pytest
-# [tool.pytest.ini_options]
-# minversion = "7.0"
-# addopts = "-ra -q --cov=src/fiberis --cov-report=html"
-# testpaths = [
-#     "tests",
-# ]
+[tool.coverage.run]
+branch = true
+source = ["fiberis"]
 
-# Example: Configuration for MyPy
-# [tool.mypy]
-# python_version = "3.9"
-# warn_return_any = true
-# warn_unused_configs = true
-# ignore_missing_imports = true # Can be helpful initially
-# exclude = ['docs/'] # Exclude directories from type checking
+[tool.coverage.report]
+show_missing = true
+skip_covered = false
+
+# MyPy configuration (kept lenient for the initial modernization pass).
+[tool.mypy]
+python_version = "3.10"
+warn_unused_configs = true
+ignore_missing_imports = true
+exclude = ['docs/', 'examples/']

--- a/src/fiberis/analyzer/TensorProcessor/coreT1D.py
+++ b/src/fiberis/analyzer/TensorProcessor/coreT1D.py
@@ -6,7 +6,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 import datetime
 from copy import deepcopy
-from typing import Optional, Union, List, Any, Dict
+from typing import Optional, Union, List, Any, Dict, Tuple
 
 # Fiberis imports
 from fiberis.utils.history_utils import InfoManagementSystem

--- a/src/fiberis/io/reader_mariner_3d.py
+++ b/src/fiberis/io/reader_mariner_3d.py
@@ -6,7 +6,7 @@
 import numpy as np
 import os
 from fiberis.io import core
-from fiberis.analyzer.Geometry3D import DataG3D
+from fiberis.analyzer.Geometry3D.coreG3D import DataG3D
 
 
 class Mariner3D(core.DataIO):

--- a/src/fiberis/io/reader_mariner_gauge1d.py
+++ b/src/fiberis/io/reader_mariner_gauge1d.py
@@ -5,7 +5,7 @@
 
 import numpy as np
 from fiberis.io import core
-from fiberis.analyzer.Data1D import Data1DGauge
+from fiberis.analyzer.Data1D.Data1D_Gauge import Data1DGauge
 import os
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,45 @@
+# Shared pytest fixtures and configuration for the fibeRIS test suite.
+#
+# These fixtures support the characterization tests that lock in the current
+# observable behavior of the package, providing a safety net for the ongoing
+# modernization/refactoring work.
+
+import datetime
+import os
+import sys
+
+import numpy as np
+import pytest
+
+# Ensure the package is importable even without an editable install.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../src")))
+
+# Use a non-interactive matplotlib backend so plotting code never blocks tests.
+import matplotlib
+
+matplotlib.use("Agg")
+
+# Absolute path to the bundled example datasets used as real-data fixtures.
+EXAMPLES_DATA_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "examples", "data")
+)
+
+
+@pytest.fixture
+def examples_data_dir():
+    """Path to the repository's bundled example data directory."""
+    return EXAMPLES_DATA_DIR
+
+
+@pytest.fixture
+def sample_start_time():
+    """A fixed, deterministic start time used across tests."""
+    return datetime.datetime(2023, 1, 1, 12, 0, 0)
+
+
+@pytest.fixture
+def sine_taxis_data():
+    """A simple, deterministic 1D time series (taxis, data)."""
+    taxis = np.linspace(0, 10, 11)
+    data = np.sin(taxis)
+    return taxis, data

--- a/tests/test_core1D_extended.py
+++ b/tests/test_core1D_extended.py
@@ -1,0 +1,695 @@
+# Characterization (golden-master) tests for the UNTESTED methods of
+# fiberis.analyzer.Data1D.core1D.Data1D.
+#
+# These tests pin the CURRENT observable behavior of the code so that a pure
+# refactor can be validated against them. Golden values were obtained by
+# actually running the code, not by reasoning about what is "correct".
+# Where behavior looks like a possible bug, the test still pins the current
+# behavior and a NOTE comment flags it.
+
+import datetime
+import os
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose, assert_array_equal
+
+from matplotlib.lines import Line2D
+
+from fiberis.analyzer.Data1D.core1D import Data1D
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+@pytest.fixture
+def linear_data(sample_start_time):
+    """A small, monotonic, easy-to-reason-about Data1D instance.
+
+    taxis = [0, 1, 2, 3, 4]; data = [0, 10, 20, 30, 40].
+    """
+    taxis = np.arange(5, dtype=float)
+    data = taxis * 10.0
+    return Data1D(data=data.copy(), taxis=taxis.copy(),
+                  start_time=sample_start_time, name="linear")
+
+
+@pytest.fixture
+def sine_obj(sine_taxis_data, sample_start_time):
+    taxis, data = sine_taxis_data
+    return Data1D(data=data.copy(), taxis=taxis.copy(),
+                  start_time=sample_start_time, name="sine")
+
+
+# ---------------------------------------------------------------------------
+# load_npz
+# ---------------------------------------------------------------------------
+class TestLoadNpz:
+    def test_load_npz_with_datetime_start_time(self, tmp_path):
+        fn = tmp_path / "dt.npz"
+        data = np.array([1, 2, 3])  # ints on purpose -> should become float
+        taxis = np.array([0, 1, 2])
+        st = datetime.datetime(2023, 5, 6, 7, 8, 9)
+        np.savez(fn, data=data, taxis=taxis, start_time=st)
+
+        d = Data1D()
+        d.load_npz(str(fn))
+
+        assert d.data.dtype == float
+        assert d.taxis.dtype == float
+        assert_array_equal(d.data, np.array([1.0, 2.0, 3.0]))
+        assert d.start_time == st
+        assert d.name == "dt.npz"
+
+    def test_load_npz_with_iso_string_start_time(self, tmp_path):
+        fn = tmp_path / "iso.npz"
+        np.savez(fn, data=np.array([1.0]), taxis=np.array([0.0]),
+                 start_time="2025-01-01T04:51:04")
+
+        d = Data1D()
+        d.load_npz(str(fn))
+        assert d.start_time == datetime.datetime(2025, 1, 1, 4, 51, 4)
+
+    def test_load_npz_real_example_file(self, examples_data_dir):
+        fn = os.path.join(examples_data_dir, "1d", "001_pressure_data_sample.npz")
+        d = Data1D()
+        d.load_npz(fn)
+        assert d.data.size == 96
+        assert d.taxis.size == 96
+        assert d.name == "001_pressure_data_sample.npz"
+        assert isinstance(d.start_time, datetime.datetime)
+
+    def test_load_npz_file_not_found(self):
+        d = Data1D()
+        with pytest.raises(FileNotFoundError):
+            d.load_npz("/nonexistent/path/to/file.npz")
+
+    def test_load_npz_missing_keys(self, tmp_path):
+        fn = tmp_path / "missing.npz"
+        np.savez(fn, data=np.array([1.0]))  # no taxis / start_time
+        d = Data1D()
+        with pytest.raises(KeyError):
+            d.load_npz(str(fn))
+
+    def test_load_npz_unsupported_start_time_type(self, tmp_path):
+        fn = tmp_path / "badtype.npz"
+        # start_time stored as an int -> not str and not datetime
+        np.savez(fn, data=np.array([1.0]), taxis=np.array([0.0]),
+                 start_time=np.array(12345))
+        d = Data1D()
+        with pytest.raises(ValueError):
+            d.load_npz(str(fn))
+
+
+# ---------------------------------------------------------------------------
+# crop / select_time
+# ---------------------------------------------------------------------------
+class TestCrop:
+    def test_crop_requires_start_time(self):
+        d = Data1D(data=np.arange(3.0), taxis=np.arange(3.0))
+        with pytest.raises(ValueError):
+            d.crop(0.0, 1.0)
+
+    def test_crop_requires_data(self, sample_start_time):
+        d = Data1D(start_time=sample_start_time)
+        with pytest.raises(ValueError):
+            d.crop(0.0, 1.0)
+
+    def test_crop_invalid_type_raises_typeerror(self, linear_data):
+        with pytest.raises(TypeError):
+            linear_data.crop("a", "b")
+
+    def test_crop_int_inputs_normalized(self, linear_data):
+        # ints are accepted and treated as seconds
+        linear_data.crop(1, 3)
+        assert_array_equal(linear_data.taxis, np.array([0.0, 1.0, 2.0]))
+        assert_array_equal(linear_data.data, np.array([10.0, 20.0, 30.0]))
+
+    def test_crop_on_empty_taxis_shifts_start_time(self, sample_start_time):
+        d = Data1D(data=np.array([]), taxis=np.array([]),
+                   start_time=sample_start_time)
+        d.crop(2.0, 5.0)
+        # start_time advanced by start_seconds (2.0), data stays empty
+        assert d.start_time == sample_start_time + datetime.timedelta(seconds=2.0)
+        assert d.taxis.size == 0
+
+    def test_crop_empty_result_shifts_start_time(self, linear_data, sample_start_time):
+        linear_data.crop(100.0, 200.0)
+        assert linear_data.data.size == 0
+        assert linear_data.taxis.size == 0
+        # start_time advanced by requested start_seconds (100)
+        assert linear_data.start_time == sample_start_time + datetime.timedelta(seconds=100.0)
+
+    def test_select_time_is_alias_for_crop(self, linear_data):
+        assert Data1D.select_time is Data1D.crop
+        linear_data.select_time(1.0, 3.0)
+        assert_array_equal(linear_data.taxis, np.array([0.0, 1.0, 2.0]))
+
+    def test_crop_datetime_clamps_negative_start_to_zero(self, linear_data, sample_start_time):
+        # start before start_time -> start_seconds clamped to 0
+        start = sample_start_time - datetime.timedelta(seconds=10)
+        end = sample_start_time + datetime.timedelta(seconds=2)
+        linear_data.crop(start, end)
+        assert_array_equal(linear_data.taxis, np.array([0.0, 1.0, 2.0]))
+        assert linear_data.start_time == sample_start_time
+
+
+# ---------------------------------------------------------------------------
+# shift
+# ---------------------------------------------------------------------------
+class TestShift:
+    def test_shift_seconds(self, linear_data, sample_start_time):
+        linear_data.shift(5.0)
+        assert linear_data.start_time == sample_start_time + datetime.timedelta(seconds=5.0)
+
+    def test_shift_timedelta(self, linear_data, sample_start_time):
+        linear_data.shift(datetime.timedelta(minutes=1))
+        assert linear_data.start_time == sample_start_time + datetime.timedelta(minutes=1)
+
+    def test_shift_negative_int(self, linear_data, sample_start_time):
+        linear_data.shift(-3)
+        assert linear_data.start_time == sample_start_time - datetime.timedelta(seconds=3)
+
+    def test_shift_requires_start_time(self):
+        d = Data1D(data=np.arange(3.0), taxis=np.arange(3.0))
+        with pytest.raises(ValueError):
+            d.shift(1.0)
+
+    def test_shift_invalid_type(self, linear_data):
+        with pytest.raises(TypeError):
+            linear_data.shift("nope")
+
+
+# ---------------------------------------------------------------------------
+# get_value_by_time
+# ---------------------------------------------------------------------------
+class TestGetValueByTime:
+    def test_float_interpolation(self, linear_data):
+        assert linear_data.get_value_by_time(1.5) == 15.0
+
+    def test_int_input(self, linear_data):
+        assert linear_data.get_value_by_time(2) == 20.0
+
+    def test_datetime_input(self, linear_data, sample_start_time):
+        tp = sample_start_time + datetime.timedelta(seconds=1)
+        assert linear_data.get_value_by_time(tp) == 10.0
+
+    def test_extrapolation_clamps_to_endpoints(self, linear_data):
+        # np.interp clamps outside the range rather than extrapolating
+        assert linear_data.get_value_by_time(-100.0) == 0.0
+        assert linear_data.get_value_by_time(100.0) == 40.0
+
+    def test_single_point_exact(self, sample_start_time):
+        d = Data1D(data=np.array([5.0]), taxis=np.array([2.0]),
+                   start_time=sample_start_time)
+        assert d.get_value_by_time(2.0) == 5.0
+
+    def test_single_point_off_returns_the_point(self, sample_start_time):
+        # NOTE: documents current behavior; np.interp on a single point returns
+        # that point's value for any query time (no true extrapolation).
+        d = Data1D(data=np.array([5.0]), taxis=np.array([2.0]),
+                   start_time=sample_start_time)
+        assert d.get_value_by_time(100.0) == 5.0
+
+    def test_empty_data_raises(self, sample_start_time):
+        d = Data1D(data=np.array([]), taxis=np.array([]),
+                   start_time=sample_start_time)
+        with pytest.raises(ValueError):
+            d.get_value_by_time(1.0)
+
+    def test_datetime_without_start_time_raises(self):
+        d = Data1D(data=np.array([1.0, 2.0]), taxis=np.array([0.0, 1.0]))
+        with pytest.raises(ValueError):
+            d.get_value_by_time(datetime.datetime(2023, 1, 1))
+
+    def test_invalid_type_raises(self, linear_data):
+        with pytest.raises(TypeError):
+            linear_data.get_value_by_time("nope")
+
+
+# ---------------------------------------------------------------------------
+# calculate_time
+# ---------------------------------------------------------------------------
+class TestCalculateTime:
+    def test_returns_datetime64_array(self, linear_data, sample_start_time):
+        out = linear_data.calculate_time()
+        assert out.size == 5
+        assert np.issubdtype(out.dtype, np.datetime64)
+        assert out[0] == np.datetime64(sample_start_time)
+        assert out[-1] == np.datetime64(sample_start_time) + np.timedelta64(4, "s")
+
+    def test_requires_start_time(self):
+        d = Data1D(taxis=np.arange(3.0))
+        with pytest.raises(ValueError):
+            d.calculate_time()
+
+    def test_requires_taxis(self, sample_start_time):
+        d = Data1D(start_time=sample_start_time)
+        with pytest.raises(ValueError):
+            d.calculate_time()
+
+
+# ---------------------------------------------------------------------------
+# copy
+# ---------------------------------------------------------------------------
+class TestCopy:
+    def test_copy_is_deep(self, linear_data):
+        c = linear_data.copy()
+        assert c is not linear_data
+        assert c.data is not linear_data.data
+        c.data[0] = 999.0
+        assert linear_data.data[0] == 0.0
+
+    def test_copy_preserves_attrs(self, linear_data):
+        c = linear_data.copy()
+        assert c.name == linear_data.name
+        assert c.start_time == linear_data.start_time
+        assert_array_equal(c.taxis, linear_data.taxis)
+
+    def test_copy_adds_history_record(self, linear_data):
+        c = linear_data.copy()
+        assert len(c.history.records) > len(linear_data.history.records)
+
+
+# ---------------------------------------------------------------------------
+# rename
+# ---------------------------------------------------------------------------
+class TestRename:
+    def test_rename_ok(self, linear_data):
+        linear_data.rename("renamed")
+        assert linear_data.name == "renamed"
+
+    def test_rename_strips_whitespace(self, linear_data):
+        linear_data.rename("  padded  ")
+        assert linear_data.name == "padded"
+
+    def test_rename_non_string_raises_typeerror(self, linear_data):
+        with pytest.raises(TypeError):
+            linear_data.rename(123)
+
+    def test_rename_empty_raises_valueerror(self, linear_data):
+        with pytest.raises(ValueError):
+            linear_data.rename("   ")
+
+
+# ---------------------------------------------------------------------------
+# down_sample
+# ---------------------------------------------------------------------------
+class TestDownSample:
+    def test_down_sample_factor_2(self, sample_start_time):
+        d = Data1D(data=np.arange(10.0), taxis=np.arange(10.0),
+                   start_time=sample_start_time)
+        d.down_sample(2)
+        assert_array_equal(d.data, np.array([0.0, 2.0, 4.0, 6.0, 8.0]))
+        assert_array_equal(d.taxis, np.array([0.0, 2.0, 4.0, 6.0, 8.0]))
+
+    def test_down_sample_factor_1_noop(self, sample_start_time):
+        d = Data1D(data=np.arange(5.0), taxis=np.arange(5.0),
+                   start_time=sample_start_time)
+        d.down_sample(1)
+        assert d.data.size == 5
+
+    def test_down_sample_zero_raises(self, sample_start_time):
+        d = Data1D(data=np.arange(5.0), taxis=np.arange(5.0),
+                   start_time=sample_start_time)
+        with pytest.raises(ValueError):
+            d.down_sample(0)
+
+    def test_down_sample_negative_raises(self, sample_start_time):
+        d = Data1D(data=np.arange(5.0), taxis=np.arange(5.0),
+                   start_time=sample_start_time)
+        with pytest.raises(ValueError):
+            d.down_sample(-2)
+
+    def test_down_sample_float_raises(self, sample_start_time):
+        d = Data1D(data=np.arange(5.0), taxis=np.arange(5.0),
+                   start_time=sample_start_time)
+        with pytest.raises(ValueError):
+            d.down_sample(2.5)
+
+    def test_down_sample_empty_data_noop(self, sample_start_time):
+        d = Data1D(data=np.array([]), taxis=np.array([]),
+                   start_time=sample_start_time)
+        d.down_sample(2)  # warning + return, no raise
+        assert d.data.size == 0
+
+    def test_down_sample_no_data_raises(self):
+        d = Data1D()
+        with pytest.raises(ValueError):
+            d.down_sample(2)
+
+
+# ---------------------------------------------------------------------------
+# get_end_time
+# ---------------------------------------------------------------------------
+class TestGetEndTime:
+    def test_timestamp(self, linear_data, sample_start_time):
+        end = linear_data.get_end_time(use_timestamp=True)
+        assert end == sample_start_time + datetime.timedelta(seconds=4.0)
+
+    def test_seconds(self, linear_data):
+        end = linear_data.get_end_time(use_timestamp=False)
+        assert end == 4.0
+        assert isinstance(end, np.float64)
+
+    def test_requires_start_time(self):
+        d = Data1D(taxis=np.arange(3.0))
+        with pytest.raises(ValueError):
+            d.get_end_time()
+
+    def test_empty_taxis_raises(self, sample_start_time):
+        d = Data1D(taxis=np.array([]), start_time=sample_start_time)
+        with pytest.raises(ValueError):
+            d.get_end_time()
+
+
+# ---------------------------------------------------------------------------
+# plot
+# ---------------------------------------------------------------------------
+class TestPlot:
+    def test_plot_returns_line2d_list(self, sine_obj):
+        import matplotlib.pyplot as plt
+        fig, ax = plt.subplots()
+        lines = sine_obj.plot(ax=ax)
+        assert isinstance(lines, list)
+        assert len(lines) == 1
+        assert isinstance(lines[0], Line2D)
+        plt.close(fig)
+
+    def test_plot_with_timestamp(self, sine_obj):
+        import matplotlib.pyplot as plt
+        fig, ax = plt.subplots()
+        lines = sine_obj.plot(ax=ax, use_timestamp=True, title="t")
+        assert len(lines) == 1
+        plt.close(fig)
+
+    def test_plot_no_axes_creates_figure(self, sine_obj):
+        import matplotlib.pyplot as plt
+        lines = sine_obj.plot()  # ax=None -> new fig, plt.show() (Agg no-op)
+        assert isinstance(lines, list) and len(lines) == 1
+        plt.close("all")
+
+    def test_plot_empty_with_axes_returns_empty_list(self, sample_start_time):
+        import matplotlib.pyplot as plt
+        d = Data1D(data=np.array([]), taxis=np.array([]),
+                   start_time=sample_start_time)
+        fig, ax = plt.subplots()
+        lines = d.plot(ax=ax)
+        assert lines == []
+        plt.close(fig)
+
+    def test_plot_no_data_raises(self):
+        d = Data1D()
+        with pytest.raises(ValueError):
+            d.plot()
+
+
+# ---------------------------------------------------------------------------
+# get_info_str / print_info / print_str / __str__
+# ---------------------------------------------------------------------------
+class TestInfoStrings:
+    def test_get_info_str_contains_name_and_lengths(self, linear_data):
+        s = linear_data.get_info_str()
+        assert "linear" in s
+        assert "Length=5" in s
+        assert "Start Time:" in s
+
+    def test_get_info_str_long_arrays_truncated(self, sample_start_time):
+        d = Data1D(data=np.arange(20.0), taxis=np.arange(20.0),
+                   start_time=sample_start_time, name="long")
+        s = d.get_info_str()
+        assert "first 10" in s
+
+    def test_get_info_str_unset_fields(self):
+        d = Data1D()
+        s = d.get_info_str()
+        assert "Unnamed" in s
+        assert "Not set" in s
+
+    def test_str_equals_get_info_str(self, linear_data):
+        assert str(linear_data) == linear_data.get_info_str()
+
+    def test_print_info(self, linear_data, capsys):
+        linear_data.print_info()
+        out = capsys.readouterr().out
+        assert "linear" in out
+
+    def test_print_str(self, linear_data, capsys):
+        linear_data.print_str()
+        out = capsys.readouterr().out
+        # both taxis line and data line printed
+        assert "0.0" in out and "40.0" in out
+
+    def test_print_str_unset(self, capsys):
+        d = Data1D()
+        d.print_str()
+        out = capsys.readouterr().out
+        assert "not set" in out.lower()
+
+
+# ---------------------------------------------------------------------------
+# right_merge
+# ---------------------------------------------------------------------------
+class TestRightMerge:
+    def test_normal_merge(self, sample_start_time):
+        a = Data1D(data=np.arange(5.0), taxis=np.arange(5.0),
+                   start_time=sample_start_time, name="a")
+        b = Data1D(data=np.arange(3.0), taxis=np.arange(3.0),
+                   start_time=sample_start_time + datetime.timedelta(seconds=15),
+                   name="b")
+        a.right_merge(b)
+        assert a.data.size == 8
+        # other taxis offset by 15s relative to a's start
+        assert a.taxis[5] == 15.0
+        assert a.taxis[-1] == 17.0
+
+    def test_empty_self_copies_other(self, sample_start_time):
+        a = Data1D(data=np.array([]), taxis=np.array([]),
+                   start_time=sample_start_time, name="a")
+        b = Data1D(data=np.arange(3.0), taxis=np.arange(3.0),
+                   start_time=sample_start_time + datetime.timedelta(seconds=2),
+                   name="b")
+        a.right_merge(b)
+        assert a.data.size == 3
+        # self adopts other's start_time
+        assert a.start_time == sample_start_time + datetime.timedelta(seconds=2)
+
+    def test_empty_other_is_noop(self, sample_start_time):
+        a = Data1D(data=np.arange(5.0), taxis=np.arange(5.0),
+                   start_time=sample_start_time, name="a")
+        empty = Data1D(data=np.array([]), taxis=np.array([]),
+                       start_time=sample_start_time + datetime.timedelta(hours=1),
+                       name="empty")
+        a.right_merge(empty)
+        assert a.data.size == 5
+
+    def test_overlap_raises(self, sample_start_time):
+        a = Data1D(data=np.arange(5.0), taxis=np.arange(5.0),
+                   start_time=sample_start_time, name="a")
+        # a ends at +4s; b starts at +2s -> overlap
+        b = Data1D(data=np.arange(3.0), taxis=np.arange(3.0),
+                   start_time=sample_start_time + datetime.timedelta(seconds=2),
+                   name="b")
+        with pytest.raises(ValueError):
+            a.right_merge(b)
+
+    def test_non_data1d_raises_typeerror(self, linear_data):
+        with pytest.raises(TypeError):
+            linear_data.right_merge("not a Data1D")
+
+    def test_missing_start_time_raises(self, sample_start_time):
+        a = Data1D(data=np.arange(5.0), taxis=np.arange(5.0),
+                   start_time=sample_start_time)
+        b = Data1D(data=np.arange(3.0), taxis=np.arange(3.0))  # no start_time
+        with pytest.raises(ValueError):
+            a.right_merge(b)
+
+
+# ---------------------------------------------------------------------------
+# remove_abnormal_data
+# ---------------------------------------------------------------------------
+class TestRemoveAbnormalData:
+    def test_mean_method(self, sample_start_time):
+        d = Data1D(data=np.array([0.0, 1.0, 1000.0, 3.0, 4.0]),
+                   taxis=np.arange(5.0), start_time=sample_start_time)
+        d.remove_abnormal_data(threshold=10.0, method="mean")
+        assert d.data[2] == 2.0  # (1 + 3) / 2
+
+    def test_interp_method(self, sample_start_time):
+        d = Data1D(data=np.array([0.0, 1.0, 1000.0, 3.0, 4.0]),
+                   taxis=np.arange(5.0), start_time=sample_start_time)
+        d.remove_abnormal_data(threshold=10.0, method="interp")
+        assert_allclose(d.data, np.array([0.0, 1.0, 2.0, 3.0, 4.0]))
+
+    def test_nan_method(self, sample_start_time):
+        d = Data1D(data=np.array([0.0, 1.0, 1000.0, 3.0, 4.0]),
+                   taxis=np.arange(5.0), start_time=sample_start_time)
+        d.remove_abnormal_data(threshold=10.0, method="nan")
+        assert np.isnan(d.data[2])
+        assert d.data[1] == 1.0 and d.data[3] == 3.0
+
+    def test_too_few_points_noop(self, sample_start_time):
+        d = Data1D(data=np.array([1.0, 1000.0]), taxis=np.array([0.0, 1.0]),
+                   start_time=sample_start_time)
+        d.remove_abnormal_data(threshold=10.0)
+        assert_array_equal(d.data, np.array([1.0, 1000.0]))
+
+    def test_no_abnormal_points_unchanged(self, sample_start_time):
+        orig = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+        d = Data1D(data=orig.copy(), taxis=np.arange(5.0),
+                   start_time=sample_start_time)
+        d.remove_abnormal_data(threshold=10.0, method="mean")
+        assert_array_equal(d.data, orig)
+
+    def test_empty_data_raises(self, sample_start_time):
+        d = Data1D(data=np.array([]), taxis=np.array([]),
+                   start_time=sample_start_time)
+        with pytest.raises(ValueError):
+            d.remove_abnormal_data()
+
+
+# ---------------------------------------------------------------------------
+# lpfilter
+# ---------------------------------------------------------------------------
+class TestLpFilter:
+    def test_lpfilter_preserves_length_and_attenuates_hf(self, sample_start_time):
+        taxis = np.linspace(0, 10, 200)
+        data = np.sin(2 * np.pi * 1 * taxis) + 0.5 * np.sin(2 * np.pi * 20 * taxis)
+        d = Data1D(data=data.copy(), taxis=taxis.copy(),
+                   start_time=sample_start_time)
+        peak_before = float(np.max(np.abs(d.data)))
+        d.lpfilter(freqcut=3.0, order=2)
+        assert d.data.size == 200
+        # high-frequency component removed -> peak amplitude reduced toward ~1
+        assert float(np.max(np.abs(d.data))) < peak_before
+
+    def test_lpfilter_empty_raises(self, sample_start_time):
+        d = Data1D(data=np.array([]), taxis=np.array([]),
+                   start_time=sample_start_time)
+        with pytest.raises(ValueError):
+            d.lpfilter(freqcut=1.0)
+
+    def test_lpfilter_single_point_noop(self, sample_start_time):
+        d = Data1D(data=np.array([1.0]), taxis=np.array([0.0]),
+                   start_time=sample_start_time)
+        d.lpfilter(freqcut=1.0)  # size < 2 -> warning + return
+        assert_array_equal(d.data, np.array([1.0]))
+
+
+# ---------------------------------------------------------------------------
+# interpolate
+# ---------------------------------------------------------------------------
+class TestInterpolate:
+    def test_nan_fill_outside_range(self, sample_start_time):
+        d = Data1D(data=np.array([0.0, 10.0, 20.0]),
+                   taxis=np.array([0.0, 1.0, 2.0]),
+                   start_time=sample_start_time)
+        d.interpolate(np.array([-1.0, 0.5, 1.5, 3.0]))
+        assert np.isnan(d.data[0])
+        assert d.data[1] == 5.0
+        assert d.data[2] == 15.0
+        assert np.isnan(d.data[3])
+
+    def test_extrapolate(self, sample_start_time):
+        d = Data1D(data=np.array([0.0, 10.0, 20.0]),
+                   taxis=np.array([0.0, 1.0, 2.0]),
+                   start_time=sample_start_time)
+        d.interpolate(np.array([-1.0, 0.5, 3.0]),
+                      fill_value_left="extrapolate",
+                      fill_value_right="extrapolate")
+        assert_allclose(d.data, np.array([-10.0, 5.0, 30.0]))
+
+    def test_new_start_time_offsets_lookup(self, sample_start_time):
+        d = Data1D(data=np.array([0.0, 10.0, 20.0]),
+                   taxis=np.array([0.0, 1.0, 2.0]),
+                   start_time=sample_start_time)
+        new_start = sample_start_time + datetime.timedelta(seconds=1)
+        # new_taxis [0,1] relative to new_start == original [1,2]
+        d.interpolate(np.array([0.0, 1.0]), new_start_time=new_start)
+        assert_allclose(d.data, np.array([10.0, 20.0]))
+        assert d.start_time == new_start
+
+    def test_empty_new_taxis_raises(self, sample_start_time):
+        d = Data1D(data=np.array([0.0, 1.0]), taxis=np.array([0.0, 1.0]),
+                   start_time=sample_start_time)
+        with pytest.raises(ValueError):
+            d.interpolate(np.array([]))
+
+    def test_non_monotonic_new_taxis_raises(self, sample_start_time):
+        d = Data1D(data=np.array([0.0, 1.0, 2.0]),
+                   taxis=np.array([0.0, 1.0, 2.0]),
+                   start_time=sample_start_time)
+        with pytest.raises(ValueError):
+            d.interpolate(np.array([2.0, 1.0, 0.0]))
+
+    def test_empty_source_raises(self, sample_start_time):
+        d = Data1D(data=np.array([]), taxis=np.array([]),
+                   start_time=sample_start_time)
+        with pytest.raises(ValueError):
+            d.interpolate(np.array([0.0, 1.0]))
+
+
+# ---------------------------------------------------------------------------
+# savez (roundtrip via load_npz)
+# ---------------------------------------------------------------------------
+class TestSavez:
+    def test_savez_roundtrip(self, linear_data, tmp_path):
+        fn = tmp_path / "out.npz"
+        linear_data.savez(str(fn))
+        assert fn.exists()
+
+        reloaded = Data1D()
+        reloaded.load_npz(str(fn))
+        assert_array_equal(reloaded.data, linear_data.data)
+        assert_array_equal(reloaded.taxis, linear_data.taxis)
+        assert reloaded.start_time == linear_data.start_time
+
+    def test_savez_appends_npz_extension(self, linear_data, tmp_path):
+        base = tmp_path / "noext"
+        linear_data.savez(str(base))
+        assert (tmp_path / "noext.npz").exists()
+
+    def test_savez_empty_raises(self, sample_start_time, tmp_path):
+        d = Data1D(data=np.array([]), taxis=np.array([]),
+                   start_time=sample_start_time)
+        with pytest.raises(ValueError):
+            d.savez(str(tmp_path / "x.npz"))
+
+
+# ---------------------------------------------------------------------------
+# adaptive_downsample
+# ---------------------------------------------------------------------------
+class TestAdaptiveDownsample:
+    def test_preserves_peak(self, sample_start_time):
+        taxis = np.linspace(0, 10, 21)
+        data = np.zeros(21)
+        data[10] = 5.0  # a single sharp peak in the middle
+        d = Data1D(data=data.copy(), taxis=taxis.copy(),
+                   start_time=sample_start_time)
+        d.adaptive_downsample(3)
+        assert_allclose(d.taxis, np.array([0.0, 5.0, 10.0]))
+        assert_allclose(d.data, np.array([0.0, 5.0, 0.0]))
+
+    def test_n_points_ge_size_noop(self, sample_start_time):
+        d = Data1D(data=np.arange(5.0), taxis=np.arange(5.0),
+                   start_time=sample_start_time)
+        d.adaptive_downsample(10)  # >= current size -> warning + return
+        assert d.data.size == 5
+
+    def test_n_points_too_small_raises(self, sample_start_time):
+        d = Data1D(data=np.arange(10.0), taxis=np.arange(10.0),
+                   start_time=sample_start_time)
+        with pytest.raises(ValueError):
+            d.adaptive_downsample(2)
+
+    def test_n_points_float_raises(self, sample_start_time):
+        d = Data1D(data=np.arange(10.0), taxis=np.arange(10.0),
+                   start_time=sample_start_time)
+        with pytest.raises(ValueError):
+            d.adaptive_downsample(3.5)
+
+    def test_empty_raises(self, sample_start_time):
+        d = Data1D(data=np.array([]), taxis=np.array([]),
+                   start_time=sample_start_time)
+        with pytest.raises(ValueError):
+            d.adaptive_downsample(3)

--- a/tests/test_core1dg.py
+++ b/tests/test_core1dg.py
@@ -1,0 +1,306 @@
+# Characterization tests for fiberis.analyzer.Data1DG.core1DG.Data1DG.
+#
+# These lock in CURRENT observable behavior to provide a safety net for a
+# refactor. Golden values were obtained by running the code, not guessed, and
+# must remain GREEN through a pure refactor.
+#
+# NOTE: tests/test_geometry.py already exercises basic Data1DG behavior
+# (initialization, select_range, shift, get_value_by_location at a node,
+# save/load roundtrip). This file does NOT duplicate those; it characterizes
+# additional behavior: constructor coercion/validation, interpolation including
+# extrapolation clamping, cropping/shift edge cases, copy semantics, info/str,
+# plotting, and guard/error paths.
+
+import os
+import sys
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose, assert_array_equal
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../src")))
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from matplotlib.lines import Line2D
+
+from fiberis.analyzer.Data1DG.core1DG import Data1DG
+
+
+@pytest.fixture
+def linear_1dg():
+    """data == daxis for easy interpolation reasoning: f(x) = x over [0, 10]."""
+    daxis = np.linspace(0, 10, 11)
+    return Data1DG(data=daxis.copy(), daxis=daxis.copy(),
+                   axis_name="Depth (m)", name="lin")
+
+
+# --------------------------------------------------------------------------- #
+# Construction                                                                 #
+# --------------------------------------------------------------------------- #
+class TestConstruction:
+    def test_default_empty_construction(self):
+        d = Data1DG()
+        assert d.data is None
+        assert d.daxis is None
+        assert d.axis_name == "Spatial Axis"
+        assert d.name is None
+        # one record logged for the empty-object path
+        assert len(d.history.records) == 1
+
+    def test_inputs_coerced_to_float_arrays(self):
+        d = Data1DG(data=[1, 2, 3], daxis=[0, 1, 2])
+        assert d.data.dtype == np.dtype(float)
+        assert d.daxis.dtype == np.dtype(float)
+        assert_array_equal(d.data, [1.0, 2.0, 3.0])
+
+    def test_named_object_logs_named_record(self):
+        d = Data1DG(name="abc")
+        assert "abc" in d.history.records[0]["description"]
+
+    def test_length_mismatch_raises(self):
+        with pytest.raises(ValueError):
+            Data1DG(data=[1.0, 2.0], daxis=[0.0, 1.0, 2.0])
+
+    def test_data_only_no_validation(self):
+        # If only one of data/daxis is provided, length check is skipped.
+        d = Data1DG(data=[1.0, 2.0, 3.0])
+        assert d.daxis is None
+        assert_array_equal(d.data, [1.0, 2.0, 3.0])
+
+
+# --------------------------------------------------------------------------- #
+# interpolation                                                                #
+# --------------------------------------------------------------------------- #
+class TestGetValueByLocation:
+    def test_value_at_node(self, linear_1dg):
+        assert linear_1dg.get_value_by_location(3.0) == 3.0
+
+    def test_value_interpolated_between_nodes(self, linear_1dg):
+        assert_allclose(linear_1dg.get_value_by_location(3.5), 3.5)
+
+    def test_returns_python_float(self, linear_1dg):
+        v = linear_1dg.get_value_by_location(2.0)
+        assert isinstance(v, float)
+
+    def test_extrapolation_is_clamped_below(self, linear_1dg):
+        # np.interp clamps to the first/last value outside the range.
+        assert linear_1dg.get_value_by_location(-100.0) == 0.0
+
+    def test_extrapolation_is_clamped_above(self, linear_1dg):
+        assert linear_1dg.get_value_by_location(100.0) == 10.0
+
+    def test_raises_when_unset(self):
+        with pytest.raises(ValueError):
+            Data1DG().get_value_by_location(1.0)
+
+    def test_raises_when_empty(self):
+        d = Data1DG(data=np.array([]), daxis=np.array([]))
+        with pytest.raises(ValueError):
+            d.get_value_by_location(1.0)
+
+
+# --------------------------------------------------------------------------- #
+# select_range / cropping                                                      #
+# --------------------------------------------------------------------------- #
+class TestSelectRange:
+    def test_inclusive_bounds(self, linear_1dg):
+        linear_1dg.select_range(2.0, 5.0)
+        assert_array_equal(linear_1dg.daxis, [2.0, 3.0, 4.0, 5.0])
+        assert_array_equal(linear_1dg.data, [2.0, 3.0, 4.0, 5.0])
+
+    def test_modifies_in_place_returns_none(self, linear_1dg):
+        assert linear_1dg.select_range(0.0, 10.0) is None
+
+    def test_empty_selection_yields_empty_arrays(self, linear_1dg):
+        linear_1dg.select_range(100.0, 200.0)
+        assert linear_1dg.daxis.size == 0
+        assert linear_1dg.data.size == 0
+
+    def test_start_greater_than_end_raises(self, linear_1dg):
+        with pytest.raises(ValueError):
+            linear_1dg.select_range(5.0, 2.0)
+
+    def test_equal_bounds_selects_single_point(self, linear_1dg):
+        linear_1dg.select_range(4.0, 4.0)
+        assert_array_equal(linear_1dg.daxis, [4.0])
+
+    def test_raises_when_daxis_unset(self):
+        with pytest.raises(ValueError):
+            Data1DG().select_range(0.0, 1.0)
+
+
+# --------------------------------------------------------------------------- #
+# shift                                                                        #
+# --------------------------------------------------------------------------- #
+class TestShift:
+    def test_positive_shift(self, linear_1dg):
+        linear_1dg.shift(5.0)
+        assert linear_1dg.daxis[0] == 5.0
+        assert linear_1dg.daxis[-1] == 15.0
+
+    def test_negative_shift(self, linear_1dg):
+        linear_1dg.shift(-2.0)
+        assert linear_1dg.daxis[0] == -2.0
+
+    def test_shift_does_not_touch_data(self, linear_1dg):
+        original = linear_1dg.data.copy()
+        linear_1dg.shift(3.0)
+        assert_array_equal(linear_1dg.data, original)
+
+    def test_shift_guard(self):
+        with pytest.raises(ValueError):
+            Data1DG().shift(1.0)
+
+
+# --------------------------------------------------------------------------- #
+# copy                                                                         #
+# --------------------------------------------------------------------------- #
+class TestCopy:
+    def test_deepcopy_independence(self, linear_1dg):
+        c = linear_1dg.copy()
+        c.daxis[0] = 999.0
+        assert linear_1dg.daxis[0] == 0.0
+
+    def test_copy_logs_extra_record(self, linear_1dg):
+        c = linear_1dg.copy()
+        assert len(c.history.records) > len(linear_1dg.history.records)
+
+    def test_copy_preserves_values(self, linear_1dg):
+        c = linear_1dg.copy()
+        assert_array_equal(c.data, linear_1dg.data)
+        assert c.name == linear_1dg.name
+        assert c.axis_name == linear_1dg.axis_name
+
+
+# --------------------------------------------------------------------------- #
+# save / load                                                                  #
+# --------------------------------------------------------------------------- #
+class TestSaveLoad:
+    def test_savez_appends_extension(self, linear_1dg, tmp_path):
+        target = tmp_path / "noext"
+        linear_1dg.savez(str(target))
+        assert (tmp_path / "noext.npz").exists()
+
+    def test_roundtrip_preserves_data_and_axis_name(self, linear_1dg, tmp_path):
+        fn = tmp_path / "r.npz"
+        linear_1dg.savez(str(fn))
+        loaded = Data1DG()
+        loaded.load_npz(str(fn))
+        assert_array_equal(loaded.data, linear_1dg.data)
+        assert_array_equal(loaded.daxis, linear_1dg.daxis)
+        assert loaded.axis_name == "Depth (m)"
+
+    def test_name_after_load_is_full_basename(self, linear_1dg, tmp_path):
+        # Unlike DataG3D, Data1DG keeps the .npz extension in the name.
+        fn = tmp_path / "profile.npz"
+        linear_1dg.savez(str(fn))
+        loaded = Data1DG()
+        loaded.load_npz(str(fn))
+        assert loaded.name == "profile.npz"
+
+    def test_savez_uses_name_when_no_filename(self, tmp_path):
+        # When filename is omitted, self.name is used as the path.
+        d = Data1DG(data=[1.0, 2.0], daxis=[0.0, 1.0],
+                    name=str(tmp_path / "byname"))
+        d.savez()
+        assert (tmp_path / "byname.npz").exists()
+
+    def test_savez_no_name_no_filename_raises(self):
+        d = Data1DG(data=[1.0], daxis=[0.0])  # name is None
+        with pytest.raises(ValueError):
+            d.savez()
+
+    def test_savez_raises_when_data_unset(self, tmp_path):
+        d = Data1DG()
+        with pytest.raises(ValueError):
+            d.savez(str(tmp_path / "x.npz"))
+
+    def test_load_missing_file_raises(self, tmp_path):
+        d = Data1DG()
+        with pytest.raises(FileNotFoundError):
+            d.load_npz(str(tmp_path / "nope.npz"))
+
+
+# --------------------------------------------------------------------------- #
+# info / str                                                                   #
+# --------------------------------------------------------------------------- #
+class TestInfo:
+    def test_info_str_unset(self):
+        s = Data1DG().get_info_str()
+        assert "Data1DG Object Summary: Unnamed" in s
+        assert "Spatial Axis (daxis): Not set" in s
+        assert "Data: Not set" in s
+        assert "Axis Name: Spatial Axis" in s
+
+    def test_info_str_populated_shows_stats(self, linear_1dg):
+        s = linear_1dg.get_info_str()
+        assert "Data1DG Object Summary: lin" in s
+        assert "Axis Name: Depth (m)" in s
+        assert "Spatial Axis (daxis): Count=11, Min=0.00, Max=10.00" in s
+        assert "Data: Count=11, Min=0.00, Max=10.00" in s
+
+    def test_str_dunder_matches_info(self, linear_1dg):
+        assert str(linear_1dg) == linear_1dg.get_info_str()
+
+    def test_print_info_runs(self, linear_1dg, capsys):
+        linear_1dg.print_info()
+        assert "Data1DG Object Summary" in capsys.readouterr().out
+
+
+# --------------------------------------------------------------------------- #
+# plotting                                                                     #
+# --------------------------------------------------------------------------- #
+class TestPlot:
+    def test_plot_returns_list_of_lines(self, linear_1dg):
+        fig, ax = plt.subplots()
+        lines = linear_1dg.plot(ax=ax)
+        assert isinstance(lines, list)
+        assert isinstance(lines[0], Line2D)
+        plt.close("all")
+
+    def test_plot_sets_axis_labels_from_axis_name(self, linear_1dg):
+        fig, ax = plt.subplots()
+        linear_1dg.plot(ax=ax)
+        assert ax.get_xlabel() == "Depth (m)"
+        assert ax.get_ylabel() == "Value"
+        plt.close("all")
+
+    def test_plot_default_title_is_name(self, linear_1dg):
+        fig, ax = plt.subplots()
+        linear_1dg.plot(ax=ax)
+        assert ax.get_title() == "lin"
+        plt.close("all")
+
+    def test_plot_custom_title(self, linear_1dg):
+        fig, ax = plt.subplots()
+        linear_1dg.plot(ax=ax, title="Custom")
+        assert ax.get_title() == "Custom"
+        plt.close("all")
+
+    def test_plot_default_label_uses_name(self, linear_1dg):
+        fig, ax = plt.subplots()
+        lines = linear_1dg.plot(ax=ax)
+        assert lines[0].get_label() == "lin"
+        plt.close("all")
+
+    def test_plot_creates_new_figure_when_ax_none(self, linear_1dg):
+        # With ax=None a new figure/axes is created and plt.show() is invoked.
+        n_before = len(plt.get_fignums())
+        lines = linear_1dg.plot()
+        assert isinstance(lines[0], Line2D)
+        assert len(plt.get_fignums()) == n_before + 1
+        plt.close("all")
+
+    def test_plot_guard_when_unset(self):
+        with pytest.raises(ValueError):
+            Data1DG().plot()
+
+    def test_plot_logs_history_record(self, linear_1dg):
+        fig, ax = plt.subplots()
+        before = len(linear_1dg.history.records)
+        linear_1dg.plot(ax=ax)
+        assert len(linear_1dg.history.records) == before + 1
+        plt.close("all")

--- a/tests/test_core2D_extended.py
+++ b/tests/test_core2D_extended.py
@@ -1,0 +1,518 @@
+# Characterization (golden-master) tests for fiberis.analyzer.Data2D.core2D.Data2D
+#
+# These tests lock in the CURRENT observable behavior of the Data2D base class
+# before a refactor. Golden values were obtained by running the code, not by
+# guessing. Tests must remain green through a pure refactor.
+#
+# Existing coverage lives in tests/test_core2D.py (initialization, set_*
+# validation, remove_timezone, load/save roundtrip, rename). This file covers
+# the remaining surface: cropping, shifting, merging, plotting, value extraction,
+# filters, MOOSE export, info/str, copy semantics, and error/guard paths.
+
+import datetime
+import os
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose, assert_array_equal
+
+import matplotlib.pyplot as plt
+from matplotlib.image import AxesImage
+from matplotlib.collections import QuadMesh
+
+from fiberis.analyzer.Data2D.core2D import Data2D
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+def synth():
+    """Deterministic 4-depth x 5-time Data2D.
+
+    data = 0..19 reshaped (4, 5); taxis = [0,1,2,3,4]; daxis = [10,20,30,40].
+    """
+    data = np.arange(20, dtype=float).reshape(4, 5)
+    taxis = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+    daxis = np.array([10.0, 20.0, 30.0, 40.0])
+    start_time = datetime.datetime(2023, 1, 1, 12, 0, 0)
+    return Data2D(data=data, taxis=taxis, daxis=daxis,
+                  start_time=start_time, name="syn")
+
+
+# --------------------------------------------------------------------------- #
+# select_time
+# --------------------------------------------------------------------------- #
+class TestSelectTime:
+    def test_select_time_seconds(self, synth):
+        synth.select_time(1.0, 3.0)
+        # taxis re-based to start at 0 from the first selected sample.
+        assert_array_equal(synth.taxis, np.array([0.0, 1.0, 2.0]))
+        assert synth.data.shape == (4, 3)
+        # First depth row originally [0,1,2,3,4] -> columns 1..3 -> [1,2,3].
+        assert_array_equal(synth.data[0], np.array([1.0, 2.0, 3.0]))
+        # start_time advanced by the actual crop offset (1 second).
+        assert synth.start_time == datetime.datetime(2023, 1, 1, 12, 0, 1)
+
+    def test_select_time_datetime(self, synth):
+        st = synth.start_time
+        synth.select_time(st + datetime.timedelta(seconds=1),
+                          st + datetime.timedelta(seconds=3))
+        assert_array_equal(synth.taxis, np.array([0.0, 1.0, 2.0]))
+        assert synth.start_time == datetime.datetime(2023, 1, 1, 12, 0, 1)
+
+    def test_select_time_int_coerced(self, synth):
+        synth.select_time(1, 3)
+        assert synth.data.shape == (4, 3)
+
+    def test_select_time_empty_range(self, synth):
+        # No samples in range: data becomes shape (n_depth, 0), taxis empty,
+        # start_time advanced by the *requested* start offset.
+        synth.select_time(100, 200)
+        assert synth.data.shape == (4, 0)
+        assert synth.taxis.size == 0
+        assert synth.start_time == datetime.datetime(2023, 1, 1, 12, 1, 40)
+
+    def test_select_time_start_after_end_raises(self, synth):
+        with pytest.raises(ValueError):
+            synth.select_time(3.0, 1.0)
+
+    def test_select_time_mixed_types_raises(self, synth):
+        with pytest.raises(TypeError):
+            synth.select_time(1.0, synth.start_time)
+
+    def test_select_time_unset_raises(self):
+        with pytest.raises(ValueError):
+            Data2D().select_time(0.0, 1.0)
+
+
+# --------------------------------------------------------------------------- #
+# select_depth
+# --------------------------------------------------------------------------- #
+class TestSelectDepth:
+    def test_select_depth_basic(self, synth):
+        synth.select_depth(20, 30)
+        # daxis is NOT re-based; values preserved.
+        assert_array_equal(synth.daxis, np.array([20.0, 30.0]))
+        assert synth.data.shape == (2, 5)
+        # depth rows 1 and 2 of the original 4x5 matrix.
+        assert_array_equal(synth.data[0], np.array([5.0, 6.0, 7.0, 8.0, 9.0]))
+
+    def test_select_depth_empty_range(self, synth):
+        synth.select_depth(100, 200)
+        assert synth.data.shape == (0, 5)
+        assert synth.daxis.size == 0
+
+    def test_select_depth_start_after_end_raises(self, synth):
+        with pytest.raises(ValueError):
+            synth.select_depth(30, 10)
+
+    def test_select_depth_bad_type_raises(self, synth):
+        with pytest.raises(TypeError):
+            synth.select_depth("a", "b")
+
+    def test_select_depth_unset_raises(self):
+        with pytest.raises(ValueError):
+            Data2D().select_depth(0, 1)
+
+
+# --------------------------------------------------------------------------- #
+# shift
+# --------------------------------------------------------------------------- #
+class TestShift:
+    def test_shift_seconds(self, synth):
+        synth.shift(5)
+        assert synth.start_time == datetime.datetime(2023, 1, 1, 12, 0, 5)
+
+    def test_shift_timedelta(self, synth):
+        synth.shift(datetime.timedelta(seconds=2))
+        assert synth.start_time == datetime.datetime(2023, 1, 1, 12, 0, 2)
+
+    def test_shift_negative(self, synth):
+        synth.shift(-1.5)
+        assert synth.start_time == datetime.datetime(2023, 1, 1, 11, 59, 58, 500000)
+
+    def test_shift_no_start_time_raises(self):
+        with pytest.raises(ValueError):
+            Data2D(data=np.ones((2, 2)), taxis=np.arange(2.0),
+                   daxis=np.arange(2.0)).shift(1.0)
+
+    def test_shift_bad_type_raises(self, synth):
+        with pytest.raises(TypeError):
+            synth.shift("1s")
+
+
+# --------------------------------------------------------------------------- #
+# right_merge
+# --------------------------------------------------------------------------- #
+class TestRightMerge:
+    def test_merge_basic(self, synth):
+        other = synth.copy()
+        other.start_time = synth.start_time + datetime.timedelta(seconds=10)
+        synth.right_merge(other)
+        assert_array_equal(
+            synth.taxis,
+            np.array([0.0, 1.0, 2.0, 3.0, 4.0, 10.0, 11.0, 12.0, 13.0, 14.0]),
+        )
+        assert synth.data.shape == (4, 10)
+
+    def test_merge_overlap_raises(self, synth):
+        other = synth.copy()
+        other.start_time = synth.start_time + datetime.timedelta(seconds=1)
+        with pytest.raises(ValueError):
+            synth.right_merge(other)
+
+    def test_merge_daxis_mismatch_raises(self, synth):
+        other = synth.copy()
+        other.daxis = np.array([1.0, 2.0, 3.0, 4.0])
+        with pytest.raises(ValueError):
+            synth.right_merge(other)
+
+    def test_merge_wrong_type_raises(self, synth):
+        with pytest.raises(TypeError):
+            synth.right_merge("not a Data2D")
+
+    def test_merge_into_empty_copies_other(self, synth):
+        empty = Data2D(data=np.empty((4, 0)), taxis=np.array([]),
+                       daxis=synth.daxis.copy(),
+                       start_time=synth.start_time, name="empty")
+        empty.right_merge(synth)
+        assert_array_equal(empty.taxis, synth.taxis)
+        assert empty.data.shape == (4, 5)
+
+    def test_merge_other_empty_noop(self, synth):
+        other = Data2D(data=np.empty((4, 0)), taxis=np.array([]),
+                       daxis=synth.daxis.copy(),
+                       start_time=synth.start_time + datetime.timedelta(seconds=10),
+                       name="empty")
+        synth.right_merge(other)
+        assert synth.data.shape == (4, 5)
+
+    def test_merge_missing_attrs_raises(self, synth):
+        with pytest.raises(ValueError):
+            synth.right_merge(Data2D())
+
+
+# --------------------------------------------------------------------------- #
+# value extraction
+# --------------------------------------------------------------------------- #
+class TestValueExtraction:
+    def test_get_value_by_time_seconds(self, synth):
+        vals, t = synth.get_value_by_time(2.0)
+        assert t == 2.0
+        # Column 2 of the matrix: [2, 7, 12, 17].
+        assert_array_equal(vals, np.array([2.0, 7.0, 12.0, 17.0]))
+
+    def test_get_value_by_time_datetime(self, synth):
+        vals, t = synth.get_value_by_time(
+            synth.start_time + datetime.timedelta(seconds=3))
+        assert t == 3.0
+        assert_array_equal(vals, np.array([3.0, 8.0, 13.0, 18.0]))
+
+    def test_get_value_by_time_empty_taxis_raises(self, synth):
+        empty = Data2D(data=np.empty((4, 0)), taxis=np.array([]),
+                       daxis=synth.daxis.copy(), start_time=synth.start_time)
+        with pytest.raises(ValueError):
+            empty.get_value_by_time(1.0)
+
+    def test_get_value_by_time_bad_type_raises(self, synth):
+        with pytest.raises(TypeError):
+            synth.get_value_by_time("now")
+
+    def test_get_value_by_depth_nearest(self, synth):
+        # depth 25 -> nearest channel is daxis index 1 (value 20).
+        out = synth.get_value_by_depth(25.0)
+        assert_array_equal(out, np.array([5.0, 6.0, 7.0, 8.0, 9.0]))
+
+    def test_get_value_by_depth_out_of_range_returns_none(self, synth):
+        assert synth.get_value_by_depth(999.0) is None
+
+    def test_get_value_by_depth_empty_daxis_returns_none(self, synth):
+        empty = Data2D(data=np.empty((0, 5)), taxis=synth.taxis.copy(),
+                       daxis=np.array([]), start_time=synth.start_time)
+        assert empty.get_value_by_depth(1.0) is None
+
+    def test_get_max_axes(self, synth):
+        assert synth.get_max_daxis() == 40.0
+        assert synth.get_max_taxis() == 4.0
+
+    def test_get_max_axes_none_when_unset(self):
+        assert Data2D().get_max_daxis() is None
+        assert Data2D().get_max_taxis() is None
+
+
+# --------------------------------------------------------------------------- #
+# time helpers
+# --------------------------------------------------------------------------- #
+class TestTimeHelpers:
+    def test_get_start_time(self, synth):
+        assert synth.get_start_time() == datetime.datetime(2023, 1, 1, 12, 0, 0)
+
+    def test_get_end_time_datetime(self, synth):
+        assert synth.get_end_time() == datetime.datetime(2023, 1, 1, 12, 0, 4)
+
+    def test_get_end_time_seconds(self, synth):
+        assert synth.get_end_time("seconds") == 4.0
+
+    def test_get_end_time_bad_format_raises(self, synth):
+        with pytest.raises(ValueError):
+            synth.get_end_time("bogus")
+
+    def test_get_end_time_none_when_unset(self):
+        assert Data2D().get_end_time() is None
+
+    def test_calculate_time(self, synth):
+        out = synth.calculate_time()
+        expected = np.array(
+            ["2023-01-01T12:00:00", "2023-01-01T12:00:01", "2023-01-01T12:00:02",
+             "2023-01-01T12:00:03", "2023-01-01T12:00:04"],
+            dtype="datetime64[s]",
+        )
+        assert_array_equal(out.astype("datetime64[s]"), expected)
+
+    def test_calculate_time_no_start_raises(self):
+        d = Data2D(taxis=np.arange(3.0))
+        with pytest.raises(ValueError):
+            d.calculate_time()
+
+    def test_calculate_time_seconds_returns_taxis(self, synth):
+        assert synth.calculate_time_seconds() is synth.taxis
+
+
+# --------------------------------------------------------------------------- #
+# filters
+# --------------------------------------------------------------------------- #
+class TestFilters:
+    @pytest.fixture
+    def noisy(self):
+        rng = np.random.default_rng(0)
+        data = rng.random((3, 100))
+        taxis = np.linspace(0, 1, 100)
+        daxis = np.arange(3.0)
+        return Data2D(data=data, taxis=taxis, daxis=daxis,
+                      start_time=datetime.datetime(2023, 1, 1))
+
+    def test_lowpass_preserves_shape(self, noisy):
+        noisy.apply_lowpass_filter(cutoff_freq=10.0)
+        assert noisy.data.shape == (3, 100)
+
+    def test_lowpass_explicit_sample_rate(self, noisy):
+        noisy.apply_lowpass_filter(cutoff_freq=10.0, sample_rate=100.0, order=3)
+        assert noisy.data.shape == (3, 100)
+
+    def test_bandpass_preserves_shape(self, noisy):
+        noisy.apply_bandpass_filter(lowcut_freq=5.0, highcut_freq=20.0)
+        assert noisy.data.shape == (3, 100)
+
+    def test_lowpass_short_taxis_skips(self):
+        d = Data2D(data=np.zeros((2, 1)), taxis=np.array([0.0]),
+                   daxis=np.arange(2.0), start_time=datetime.datetime(2023, 1, 1))
+        d.apply_lowpass_filter(5.0)  # no raise, no-op
+        assert d.data.shape == (2, 1)
+
+    def test_lowpass_unset_raises(self):
+        with pytest.raises(ValueError):
+            Data2D().apply_lowpass_filter(5.0)
+
+    def test_bandpass_unset_raises(self):
+        with pytest.raises(ValueError):
+            Data2D().apply_bandpass_filter(1.0, 5.0)
+
+
+# --------------------------------------------------------------------------- #
+# plotting (Agg backend; assert no-raise / return types)
+# --------------------------------------------------------------------------- #
+class TestPlotting:
+    def teardown_method(self):
+        plt.close("all")
+
+    def test_plot_pcolormesh(self, synth):
+        fig, ax = plt.subplots()
+        art = synth.plot(ax=ax, method="pcolormesh")
+        assert isinstance(art, QuadMesh)
+
+    def test_plot_imshow(self, synth):
+        fig, ax = plt.subplots()
+        art = synth.plot(ax=ax, method="imshow")
+        assert isinstance(art, AxesImage)
+
+    def test_plot_imshow_timestamp(self, synth):
+        fig, ax = plt.subplots()
+        art = synth.plot(ax=ax, method="imshow", use_timestamp=True)
+        assert isinstance(art, AxesImage)
+
+    def test_plot_colorbar_and_clim(self, synth):
+        fig, ax = plt.subplots()
+        art = synth.plot(ax=ax, method="pcolormesh", colorbar=True,
+                         clim=(0.0, 10.0), clabel="amp")
+        assert isinstance(art, QuadMesh)
+
+    def test_plot_invalid_method_raises(self, synth):
+        fig, ax = plt.subplots()
+        with pytest.raises(ValueError):
+            synth.plot(ax=ax, method="bogus")
+
+    def test_plot_unset_data_raises(self):
+        with pytest.raises(ValueError):
+            Data2D().plot()
+
+    def test_plot_empty_returns_none(self, synth):
+        synth.select_time(100, 200)  # makes data empty along time axis
+        fig, ax = plt.subplots()
+        assert synth.plot(ax=ax) is None
+
+    def test_plot_legacy_usetimestamp_kwarg(self, synth):
+        fig, ax = plt.subplots()
+        art = synth.plot(ax=ax, method="imshow", useTimeStamp=True)
+        assert isinstance(art, AxesImage)
+
+
+# --------------------------------------------------------------------------- #
+# info / str
+# --------------------------------------------------------------------------- #
+class TestInfoStr:
+    def test_get_info_str_populated(self, synth):
+        s = synth.get_info_str()
+        assert "Data2D Object Summary: syn" in s
+        assert "Data Shape: (4, 5)" in s
+        assert "Time Axis (taxis): Length=5" in s
+        assert "Depth Axis (daxis): Length=4" in s
+
+    def test_str_equals_info_str(self, synth):
+        assert str(synth) == synth.get_info_str()
+
+    def test_info_str_empty(self):
+        s = Data2D().get_info_str()
+        assert "Unnamed" in s
+        assert "Data: Not set" in s
+        assert "Time Axis (taxis): Not set" in s
+
+    def test_info_str_long_axis_truncates(self):
+        d = Data2D(data=np.zeros((20, 20)), taxis=np.arange(20.0),
+                   daxis=np.arange(20.0))
+        s = d.get_info_str()
+        assert "first 10" in s
+
+    def test_print_info_runs(self, synth, capsys):
+        synth.print_info()
+        out = capsys.readouterr().out
+        assert "Data2D Object Summary" in out
+
+
+# --------------------------------------------------------------------------- #
+# MOOSE reporter export
+# --------------------------------------------------------------------------- #
+class TestMooseReporter:
+    def test_basic_structure(self, synth):
+        out = synth.to_moose_reporter_str(coord_x=1.0, coord_y=2.0)
+        assert "measurement_points" in out
+        assert "measurement_time" in out
+        assert "measurement_values" in out
+        # 4 depths x 5 times = 20 measurements.
+        assert "Total measurements: 20" in out
+
+    def test_values_are_fortran_flatten(self, synth):
+        out = synth.to_moose_reporter_str(coord_x=0.0, coord_y=0.0, precision=1)
+        values_line = [ln for ln in out.splitlines()
+                       if "measurement_values" in ln][0]
+        # Fortran-order flatten of arange(20).reshape(4,5): first column 0,5,10,15.
+        assert "0.0   5.0   10.0   15.0" in values_line
+
+    def test_requires_exactly_one_none_coord(self, synth):
+        with pytest.raises(ValueError):
+            synth.to_moose_reporter_str(coord_x=1, coord_y=2, coord_z=3)
+        with pytest.raises(ValueError):
+            synth.to_moose_reporter_str(coord_x=1)  # two None
+
+    def test_unset_data_raises(self):
+        with pytest.raises(ValueError):
+            Data2D().to_moose_reporter_str(coord_x=1.0, coord_y=2.0)
+
+
+# --------------------------------------------------------------------------- #
+# copy semantics
+# --------------------------------------------------------------------------- #
+class TestCopy:
+    def test_deepcopy_independent(self):
+        a = Data2D(data=np.ones((2, 2)), taxis=np.arange(2.0),
+                   daxis=np.arange(2.0), name="c")
+        b = a.copy()
+        b.data[0, 0] = 99.0
+        assert a.data[0, 0] == 1.0  # deep copy is independent
+
+    def test_shallow_copy_shares_data(self):
+        import copy as _copy
+        a = Data2D(data=np.ones((2, 2)), taxis=np.arange(2.0),
+                   daxis=np.arange(2.0), name="c")
+        c = _copy.copy(a)
+        c.data[0, 0] = 77.0
+        # NOTE: __copy__ shares the underlying ndarray (shallow copy semantics).
+        assert a.data[0, 0] == 77.0
+
+    def test_copy_has_independent_history(self, synth):
+        b = synth.copy()
+        n_before = len(synth.history.records)
+        b.history.add_record("extra")
+        assert len(synth.history.records) == n_before
+
+
+# --------------------------------------------------------------------------- #
+# I/O: savez roundtrip + load error paths
+# --------------------------------------------------------------------------- #
+class TestIO:
+    def test_savez_load_roundtrip(self, synth, tmp_path):
+        fn = str(tmp_path / "out")  # no extension; savez appends .npz
+        synth.savez(fn)
+        assert os.path.exists(fn + ".npz")
+        loaded = Data2D()
+        loaded.load_npz(fn)
+        assert_allclose(loaded.data, synth.data)
+        assert_allclose(loaded.taxis, synth.taxis)
+        assert_allclose(loaded.daxis, synth.daxis)
+        assert loaded.start_time == synth.start_time
+        assert loaded.name == "out.npz"
+
+    def test_savez_without_data_raises(self, tmp_path):
+        with pytest.raises(ValueError):
+            Data2D().savez(str(tmp_path / "x"))
+
+    def test_load_npz_missing_file_raises(self):
+        with pytest.raises(FileNotFoundError):
+            Data2D().load_npz("/no/such/file.npz")
+
+    def test_load_real_example(self, examples_data_dir):
+        path = os.path.join(examples_data_dir, "2d", "fiberis_format",
+                            "DASdata_example.npz")
+        d = Data2D()
+        d.load_npz(path)
+        # Real DAS dataset: data converted to float, axes wired up.
+        assert d.data.shape == (6100, 258)
+        assert d.data.dtype == np.float64
+        assert d.taxis.shape == (258,)
+        assert d.daxis.shape == (6100,)
+        assert d.name == "DASdata_example.npz"
+        # start_time parsed from tz-aware datetime64/object in the file.
+        assert d.start_time.year == 2019
+        assert d.start_time.month == 3
+        assert d.start_time.day == 28
+
+
+# --------------------------------------------------------------------------- #
+# misc setters / logging compatibility
+# --------------------------------------------------------------------------- #
+class TestMisc:
+    def test_record_log_and_history(self, synth):
+        n_before = len(synth.history.records)
+        synth.record_log("hello", "world", level="WARNING")
+        assert len(synth.history.records) == n_before + 1
+
+    def test_print_log_runs(self, synth):
+        synth.print_log()  # no raise
+
+    def test_set_filename_joins(self, synth):
+        synth.set_filename("a", "b", "c")
+        assert synth.name == "a_b_c"
+
+    def test_set_name_bad_type_raises(self, synth):
+        with pytest.raises(TypeError):
+            synth.set_name(123)

--- a/tests/test_core3D_extended.py
+++ b/tests/test_core3D_extended.py
@@ -1,0 +1,212 @@
+# Characterization tests for fiberis.analyzer.Data3D.core3D.Data3D
+# and the Data3D_microseismic stub module.
+#
+# These lock in CURRENT observable behavior to provide a safety net for a
+# refactor. Golden values were obtained by running the code, not guessed.
+# They must remain GREEN through a pure refactor.
+#
+# Existing coverage lives in tests/test_core3D.py (initialization, basic
+# save/load roundtrip, save validation, info_str). This file deliberately does
+# NOT duplicate those and instead characterizes additional behavior.
+
+import os
+import sys
+
+import numpy as np
+import pytest
+from numpy.testing import assert_array_equal
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../src")))
+
+from fiberis.analyzer.Data3D.core3D import Data3D
+from fiberis.analyzer.Data3D import Data3D_microseismic
+
+
+@pytest.fixture
+def small_data3d():
+    """A tiny deterministic Data3D: 3 spatial points x 2 time steps."""
+    d = Data3D(name="well_A")
+    d.data = np.arange(6, dtype=float).reshape(3, 2)
+    d.taxis = np.array([0.0, 1.0])
+    d.xaxis = np.array([10.0, 20.0, 30.0])
+    d.yaxis = np.array([100.0, 200.0, 300.0])
+    d.variable_name = "pressure"
+    return d
+
+
+# --------------------------------------------------------------------------- #
+# Construction / history                                                       #
+# --------------------------------------------------------------------------- #
+class TestConstruction:
+    def test_default_name_is_none(self):
+        d = Data3D()
+        assert d.name is None
+        assert d.data is None
+        assert d.taxis is None
+        assert d.xaxis is None
+        assert d.yaxis is None
+        assert d.variable_name is None
+
+    def test_init_logs_one_history_record(self):
+        d = Data3D()
+        assert len(d.history.records) == 1
+        rec = d.history.records[0]
+        assert rec["level"] == "INFO"
+        assert "initialized" in rec["description"].lower()
+
+    def test_name_passed_through(self):
+        d = Data3D(name="my_sampler")
+        assert d.name == "my_sampler"
+
+
+# --------------------------------------------------------------------------- #
+# save/load roundtrips and filename handling                                   #
+# --------------------------------------------------------------------------- #
+class TestSaveLoad:
+    def test_savez_appends_npz_extension(self, small_data3d, tmp_path):
+        target = tmp_path / "no_extension"
+        small_data3d.savez(str(target))
+        # The file written has the .npz suffix appended.
+        assert (tmp_path / "no_extension.npz").exists()
+        assert not target.exists()
+
+    def test_load_npz_appends_extension(self, small_data3d, tmp_path):
+        target = tmp_path / "round"
+        small_data3d.savez(str(target))  # writes round.npz
+
+        loaded = Data3D()
+        loaded.load_npz(str(target))  # given without extension
+        assert_array_equal(loaded.data, small_data3d.data)
+
+    def test_roundtrip_preserves_dtypes_and_values(self, small_data3d, tmp_path):
+        fn = tmp_path / "r.npz"
+        small_data3d.savez(str(fn))
+        loaded = Data3D()
+        loaded.load_npz(str(fn))
+        assert_array_equal(loaded.data, small_data3d.data)
+        assert_array_equal(loaded.taxis, small_data3d.taxis)
+        assert_array_equal(loaded.xaxis, small_data3d.xaxis)
+        assert_array_equal(loaded.yaxis, small_data3d.yaxis)
+        assert loaded.variable_name == "pressure"
+        assert loaded.name == "well_A"
+
+    def test_load_npz_stringifies_name_and_variable_name(self, small_data3d, tmp_path):
+        # variable_name/name are coerced via str() on load. A genuine None is
+        # therefore round-tripped as the literal string 'None'.
+        # NOTE: possible bug - None becomes the string 'None' rather than None.
+        d = Data3D()  # name is None
+        d.data = np.zeros((1, 1))
+        d.taxis = np.array([0.0])
+        d.xaxis = np.array([0.0])
+        d.yaxis = np.array([0.0])
+        # variable_name left as None
+        fn = tmp_path / "nones.npz"
+        d.savez(str(fn))
+
+        loaded = Data3D()
+        loaded.load_npz(str(fn))
+        assert loaded.name == "None"
+        assert isinstance(loaded.name, str)
+        assert loaded.variable_name == "None"
+        assert isinstance(loaded.variable_name, str)
+
+    def test_load_missing_file_raises_filenotfound(self, tmp_path):
+        d = Data3D()
+        with pytest.raises(FileNotFoundError):
+            d.load_npz(str(tmp_path / "does_not_exist.npz"))
+        # An ERROR record is logged before the raise.
+        assert any(r["level"] == "ERROR" for r in d.history.records)
+
+    def test_load_npz_missing_key_raises_keyerror(self, tmp_path):
+        # An .npz missing a required key (e.g. 'yaxis') raises KeyError and
+        # logs an ERROR record.
+        fn = tmp_path / "incomplete.npz"
+        np.savez(
+            str(fn),
+            data=np.zeros((1, 1)),
+            taxis=np.array([0.0]),
+            xaxis=np.array([0.0]),
+            variable_name="p",
+            name="n",
+        )  # no 'yaxis'
+        d = Data3D()
+        with pytest.raises(KeyError):
+            d.load_npz(str(fn))
+        assert any(r["level"] == "ERROR" for r in d.history.records)
+
+    def test_savez_records_success_in_history(self, small_data3d, tmp_path):
+        before = len(small_data3d.history.records)
+        small_data3d.savez(str(tmp_path / "h.npz"))
+        assert len(small_data3d.history.records) == before + 1
+        assert "saved" in small_data3d.history.records[-1]["description"].lower()
+
+
+# --------------------------------------------------------------------------- #
+# save guard / validation                                                      #
+# --------------------------------------------------------------------------- #
+class TestSaveValidation:
+    @pytest.mark.parametrize("missing", ["data", "taxis", "xaxis", "yaxis"])
+    def test_savez_raises_when_any_axis_missing(self, small_data3d, tmp_path, missing):
+        setattr(small_data3d, missing, None)
+        with pytest.raises(ValueError):
+            small_data3d.savez(str(tmp_path / "fail.npz"))
+
+    def test_savez_validation_logs_error(self, tmp_path):
+        d = Data3D()
+        with pytest.raises(ValueError):
+            d.savez(str(tmp_path / "x.npz"))
+        assert any(r["level"] == "ERROR" for r in d.history.records)
+
+
+# --------------------------------------------------------------------------- #
+# info / str                                                                   #
+# --------------------------------------------------------------------------- #
+class TestInfo:
+    def test_info_str_unset_object(self):
+        s = Data3D().get_info_str()
+        assert "Data3D Object Summary: Unnamed" in s
+        assert "Name: Not set" in s
+        assert "Variable Name: Not set" in s
+        assert "Data: Not set" in s
+        assert "Time Axis (taxis): Not set" in s
+        assert "X Axis (xaxis): Not set" in s
+        assert "Y Axis (yaxis): Not set" in s
+
+    def test_info_str_small_axes_show_values_with_ellipsis(self, small_data3d):
+        s = small_data3d.get_info_str()
+        assert "Data Shape: (3, 2)" in s
+        assert "Time Axis (taxis): Length=2" in s
+        assert "X Axis (xaxis): Length=3" in s
+        assert "Y Axis (yaxis): Length=3" in s
+        # Even for short axes, an ellipsis is appended after the values.
+        assert "Values (first 10): [10. 20. 30.]..." in s
+
+    def test_info_str_long_axis_truncates_to_first_10(self):
+        d = Data3D(name="big")
+        d.data = np.zeros((20, 1))
+        d.taxis = np.array([0.0])
+        d.xaxis = np.arange(20, dtype=float)
+        d.yaxis = np.arange(20, dtype=float)
+        s = d.get_info_str()
+        assert "X Axis (xaxis): Length=20" in s
+        # Only the first 10 elements are shown for an axis of size >= 10.
+        assert "Values (first 10): [0. 1. 2. 3. 4. 5. 6. 7. 8. 9.]..." in s
+
+    def test_str_dunder_matches_get_info_str(self, small_data3d):
+        assert str(small_data3d) == small_data3d.get_info_str()
+
+    def test_print_info_runs(self, small_data3d, capsys):
+        small_data3d.print_info()
+        out = capsys.readouterr().out
+        assert "Data3D Object Summary" in out
+
+
+# --------------------------------------------------------------------------- #
+# Data3D_microseismic stub module                                              #
+# --------------------------------------------------------------------------- #
+class TestMicroseismicStub:
+    def test_module_imports_and_is_effectively_empty(self):
+        # The microseismic module is currently a placeholder stub with no
+        # public classes/functions defined.
+        public = [n for n in dir(Data3D_microseismic) if not n.startswith("__")]
+        assert public == []

--- a/tests/test_data1d_specialized.py
+++ b/tests/test_data1d_specialized.py
@@ -1,0 +1,159 @@
+# Characterization (golden-master) tests for the specialized Data1D subclasses:
+#   - Data1DGauge        (Data1D_Gauge.py)
+#   - Data1DPumpingCurve (Data1D_PumpingCurve.py)
+#   - Data1D_MOOSEps     (Data1D_MOOSEps.py)
+#
+# These pin the CURRENT observable behavior of the subclass-specific methods
+# plus verify that inherited Data1D behavior continues to work. Golden values
+# were obtained by running the code, not by assuming what is "correct".
+
+import datetime
+
+import numpy as np
+import pytest
+from numpy.testing import assert_array_equal
+
+from fiberis.analyzer.Data1D.core1D import Data1D
+from fiberis.analyzer.Data1D.Data1D_Gauge import Data1DGauge
+from fiberis.analyzer.Data1D.Data1D_PumpingCurve import Data1DPumpingCurve
+from fiberis.analyzer.Data1D.Data1D_MOOSEps import Data1D_MOOSEps
+
+
+# ===========================================================================
+# Data1DGauge
+# ===========================================================================
+class TestData1DGauge:
+    @pytest.fixture
+    def gauge(self, sample_start_time):
+        return Data1DGauge(data=np.array([1.0, 2.0, 3.0]),
+                           taxis=np.array([0.0, 1.0, 2.0]),
+                           start_time=sample_start_time, name="gauge")
+
+    def test_is_subclass_of_data1d(self):
+        assert issubclass(Data1DGauge, Data1D)
+
+    def test_instance_is_data1d(self, gauge):
+        assert isinstance(gauge, Data1D)
+
+    def test_calculate_pressure_dropdown_stub_returns_zero(self, gauge):
+        # NOTE: documents current behavior; method is an unimplemented stub
+        # that always returns 0 regardless of arguments.
+        assert gauge.calculate_pressure_dropdown() == 0
+        assert gauge.calculate_pressure_dropdown(start_time=0, end_time=1) == 0
+
+    def test_inherits_crop(self, gauge, sample_start_time):
+        gauge.crop(1.0, 2.0)
+        assert_array_equal(gauge.taxis, np.array([0.0, 1.0]))
+        assert_array_equal(gauge.data, np.array([2.0, 3.0]))
+        assert gauge.start_time == sample_start_time + datetime.timedelta(seconds=1)
+
+    def test_inherits_get_value_by_time(self, gauge):
+        assert gauge.get_value_by_time(0.5) == 1.5
+
+    def test_inherits_get_end_time(self, gauge, sample_start_time):
+        assert gauge.get_end_time(use_timestamp=False) == 2.0
+
+
+# ===========================================================================
+# Data1DPumpingCurve
+# ===========================================================================
+class TestData1DPumpingCurve:
+    @pytest.fixture
+    def pc(self, sample_start_time):
+        return Data1DPumpingCurve(data=np.array([0.0, 5.0, 10.0]),
+                                  taxis=np.array([0.0, 2.0, 4.0]),
+                                  start_time=sample_start_time, name="pc")
+
+    def test_is_subclass_of_data1d(self):
+        assert issubclass(Data1DPumpingCurve, Data1D)
+
+    def test_get_start_time_default(self, pc, sample_start_time):
+        # min_index is always 0, so start time == start_time + taxis[0] == start_time
+        assert pc.get_start_time() == sample_start_time
+
+    def test_get_start_time_with_threshold_kwarg_ignored(self, pc, sample_start_time):
+        # NOTE: documents current behavior; the 'threshold' kwarg is read but
+        # never used to select an index (min_index is hard-coded to 0).
+        assert pc.get_start_time(threshold=999.0) == sample_start_time
+
+    def test_get_start_time_no_start_time_raises(self):
+        pc = Data1DPumpingCurve(data=np.array([0.0, 5.0]),
+                                taxis=np.array([0.0, 2.0]))
+        with pytest.raises(ValueError):
+            pc.get_start_time()
+
+    def test_get_end_time_datetime_default(self, pc, sample_start_time):
+        # PumpingCurve overrides get_end_time with signature usedatetime=True
+        assert pc.get_end_time() == sample_start_time + datetime.timedelta(seconds=4.0)
+
+    def test_get_end_time_seconds(self, pc):
+        # NOTE: documents current behavior; the seconds branch returns the raw
+        # taxis element (a numpy float), unlike the base class which wraps it
+        # in np.float64 and uses the 'use_timestamp' parameter name.
+        assert pc.get_end_time(usedatetime=False) == 4.0
+
+    def test_get_end_time_threshold_kwarg_ignored(self, pc, sample_start_time):
+        # end_index is hard-coded to len(data)-1 regardless of threshold
+        assert pc.get_end_time(threshold=999.0) == \
+            sample_start_time + datetime.timedelta(seconds=4.0)
+
+    def test_get_end_time_no_start_time_raises(self):
+        pc = Data1DPumpingCurve(data=np.array([0.0, 5.0]),
+                                taxis=np.array([0.0, 2.0]))
+        with pytest.raises(ValueError):
+            pc.get_end_time()
+
+    def test_inherits_crop(self, pc, sample_start_time):
+        pc.crop(2.0, 4.0)
+        assert_array_equal(pc.data, np.array([5.0, 10.0]))
+        assert pc.start_time == sample_start_time + datetime.timedelta(seconds=2)
+
+    def test_inherits_copy(self, pc):
+        c = pc.copy()
+        assert isinstance(c, Data1DPumpingCurve)
+        assert c is not pc
+
+
+# ===========================================================================
+# Data1D_MOOSEps
+# ===========================================================================
+class TestData1DMOOSEps:
+    def test_is_subclass_of_data1d(self):
+        assert issubclass(Data1D_MOOSEps, Data1D)
+
+    def test_init_only_takes_name(self):
+        m = Data1D_MOOSEps(name="moose")
+        assert m.name == "moose"
+        assert m.data is None
+        assert m.taxis is None
+        assert m.start_time is None
+
+    def test_init_without_name(self):
+        m = Data1D_MOOSEps()
+        assert m.name is None
+
+    def test_init_adds_history_records(self):
+        # parent __init__ adds one record, the subclass adds another.
+        m = Data1D_MOOSEps(name="moose")
+        assert len(m.history.records) >= 2
+
+    def test_inherits_load_npz(self, tmp_path):
+        fn = tmp_path / "moose.npz"
+        np.savez(fn, data=np.array([1.0, 2.0, 3.0]),
+                 taxis=np.array([0.0, 1.0, 2.0]),
+                 start_time=datetime.datetime(2023, 1, 1, 12, 0, 0))
+        m = Data1D_MOOSEps(name="moose")
+        m.load_npz(str(fn))
+        assert m.data.size == 3
+        # load_npz overrides name with the basename of the file
+        assert m.name == "moose.npz"
+
+    def test_inherits_processing_after_load(self, tmp_path, sample_start_time):
+        fn = tmp_path / "moose2.npz"
+        np.savez(fn, data=np.arange(10.0), taxis=np.arange(10.0),
+                 start_time=sample_start_time)
+        m = Data1D_MOOSEps(name="m")
+        m.load_npz(str(fn))
+        m.down_sample(2)
+        assert m.data.size == 5
+        assert m.get_value_by_time(4.0) == 4.0

--- a/tests/test_data2d_dss.py
+++ b/tests/test_data2d_dss.py
@@ -1,0 +1,83 @@
+# Characterization tests for fiberis.analyzer.Data2D.Data2D_XT_DSS.DSS2D
+#
+# DSS2D subclasses Data2D and adds simple_plot() and downsampling().
+# Golden values were obtained by running the code. Tests must stay green
+# through a pure refactor.
+
+import datetime
+import os
+
+import numpy as np
+import pytest
+from numpy.testing import assert_array_equal
+
+import matplotlib.pyplot as plt
+
+from fiberis.analyzer.Data2D.Data2D_XT_DSS import DSS2D
+from fiberis.analyzer.Data2D.core2D import Data2D
+
+
+@pytest.fixture
+def dss():
+    """Deterministic 6-depth x 8-time DSS2D (data = 0..47 reshaped)."""
+    data = np.arange(48, dtype=float).reshape(6, 8)
+    taxis = np.arange(8, dtype=float)
+    daxis = np.arange(6, dtype=float) * 10.0
+    return DSS2D(data=data, taxis=taxis, daxis=daxis,
+                 start_time=datetime.datetime(2023, 1, 1), name="dss")
+
+
+class TestDSS2DInheritance:
+    def test_is_data2d_subclass(self, dss):
+        assert isinstance(dss, Data2D)
+
+    def test_inherited_methods_work(self, dss):
+        vals, t = dss.get_value_by_time(3.0)
+        assert t == 3.0
+        assert dss.get_max_taxis() == 7.0
+
+
+class TestDownsampling:
+    def test_downsampling_default(self, dss):
+        # default factor_t=2, factor_d=2 -> stride slicing.
+        dss.downsampling()
+        assert dss.data.shape == (3, 4)
+        assert_array_equal(dss.taxis, np.array([0.0, 2.0, 4.0, 6.0]))
+        assert_array_equal(dss.daxis, np.array([0.0, 20.0, 40.0]))
+
+    def test_downsampling_custom_factors(self, dss):
+        dss.downsampling(factor_t=2, factor_d=3)
+        assert dss.data.shape == (2, 4)
+        assert_array_equal(dss.taxis, np.array([0.0, 2.0, 4.0, 6.0]))
+        assert_array_equal(dss.daxis, np.array([0.0, 30.0]))
+        # data[::3, ::2]: rows 0 and 3, columns 0,2,4,6.
+        assert_array_equal(dss.data[0], np.array([0.0, 2.0, 4.0, 6.0]))
+        assert_array_equal(dss.data[1], np.array([24.0, 26.0, 28.0, 30.0]))
+
+    def test_downsampling_records_history(self, dss):
+        n_before = len(dss.history.records)
+        dss.downsampling()
+        assert len(dss.history.records) == n_before + 1
+
+
+class TestSimplePlot:
+    def teardown_method(self):
+        plt.close("all")
+
+    def test_simple_plot_runs(self, dss):
+        dss.simple_plot()  # no raise (Agg backend; plt.show is a no-op)
+        assert plt.get_fignums()  # a figure was created
+
+    def test_simple_plot_custom_kwargs(self, dss):
+        dss.simple_plot(cmap="plasma", title="custom", xlabel="t", ylabel="d")
+        assert plt.get_fignums()
+
+
+class TestDSSLoadRealExample:
+    def test_load_npz_into_dss(self, examples_data_dir):
+        path = os.path.join(examples_data_dir, "2d", "fiberis_format",
+                            "DASdata_example.npz")
+        d = DSS2D()
+        d.load_npz(path)
+        assert d.data.shape == (6100, 258)
+        assert isinstance(d, Data2D)

--- a/tests/test_geometry_extended.py
+++ b/tests/test_geometry_extended.py
@@ -1,0 +1,265 @@
+# Characterization tests for fiberis.analyzer.Geometry3D.coreG3D.DataG3D
+# and fiberis.analyzer.Geometry3D.DataG3D_md.G3DMeasuredDepth.
+#
+# These lock in CURRENT observable behavior to provide a safety net for a
+# refactor. Golden values were obtained by running the code, not guessed.
+#
+# Existing coverage lives in tests/test_geometry.py (calculate_md straight/
+# diagonal lines, save/load roundtrip, save validation). This file does NOT
+# duplicate those and instead characterizes additional behavior: filename
+# handling, MD edge cases, info/str, plotting (line/scatter/guards), and the
+# measured-depth subclass stubs.
+
+import os
+import sys
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose, assert_array_equal
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../src")))
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from matplotlib.lines import Line2D
+
+from fiberis.analyzer.Geometry3D.coreG3D import DataG3D
+from fiberis.analyzer.Geometry3D.DataG3D_md import G3DMeasuredDepth
+
+
+@pytest.fixture
+def straight_well():
+    """A straight wellbore along x: x=0..4, y=z=0."""
+    t = np.linspace(0, 4, 5)
+    g = DataG3D()
+    g.xaxis = t.copy()
+    g.yaxis = np.zeros_like(t)
+    g.zaxis = np.zeros_like(t)
+    g.data = np.zeros_like(t)
+    g.name = "straight"
+    return g
+
+
+# --------------------------------------------------------------------------- #
+# Construction                                                                 #
+# --------------------------------------------------------------------------- #
+class TestConstruction:
+    def test_default_attributes_are_none(self):
+        g = DataG3D()
+        assert g.data is None
+        assert g.xaxis is None
+        assert g.yaxis is None
+        assert g.zaxis is None
+        assert g.name is None
+
+    def test_history_starts_empty(self):
+        # Unlike Data3D, DataG3D.__init__ does not log a record.
+        g = DataG3D()
+        assert g.history.records == []
+
+
+# --------------------------------------------------------------------------- #
+# measured depth                                                               #
+# --------------------------------------------------------------------------- #
+class TestCalculateMD:
+    def test_md_3d_path(self):
+        # Path with steps along z too, to exercise the full 3D distance.
+        g = DataG3D()
+        g.xaxis = np.array([0.0, 3.0, 3.0])
+        g.yaxis = np.array([0.0, 0.0, 4.0])
+        g.zaxis = np.array([0.0, 0.0, 0.0])
+        g.data = np.zeros(3)
+        md = g.calculate_md()
+        # step1 = 3, step2 = 4 -> cumulative [0, 3, 7]
+        assert_allclose(md, [0.0, 3.0, 7.0])
+
+    def test_md_with_z_component(self):
+        g = DataG3D()
+        g.xaxis = np.array([0.0, 0.0])
+        g.yaxis = np.array([0.0, 0.0])
+        g.zaxis = np.array([0.0, 5.0])
+        g.data = np.zeros(2)
+        assert_allclose(g.calculate_md(), [0.0, 5.0])
+
+    def test_md_single_point(self):
+        g = DataG3D()
+        g.xaxis = np.array([7.0])
+        g.yaxis = np.array([2.0])
+        g.zaxis = np.array([1.0])
+        g.data = np.array([0.0])
+        # diff over a single element is empty; result is just [0.0].
+        assert_array_equal(g.calculate_md(), np.array([0.0]))
+
+    def test_md_first_value_is_zero(self, straight_well):
+        md = straight_well.calculate_md()
+        assert md[0] == 0.0
+        assert len(md) == len(straight_well.xaxis)
+
+    def test_md_does_not_mutate_axes(self, straight_well):
+        x0 = straight_well.xaxis.copy()
+        straight_well.calculate_md()
+        assert_array_equal(straight_well.xaxis, x0)
+
+
+# --------------------------------------------------------------------------- #
+# save / load                                                                  #
+# --------------------------------------------------------------------------- #
+class TestSaveLoad:
+    def test_savez_appends_extension(self, straight_well, tmp_path):
+        target = tmp_path / "noext"
+        straight_well.savez(str(target))
+        assert (tmp_path / "noext.npz").exists()
+
+    def test_name_after_load_is_basename_without_extension(self, straight_well, tmp_path):
+        fn = tmp_path / "well_42.npz"
+        straight_well.savez(str(fn))
+        loaded = DataG3D()
+        loaded.load_npz(str(fn))
+        # name is derived from the path: basename minus the 4-char extension.
+        assert loaded.name == "well_42"
+
+    def test_load_appends_extension(self, straight_well, tmp_path):
+        target = tmp_path / "wname"
+        straight_well.savez(str(target))
+        loaded = DataG3D()
+        loaded.load_npz(str(target))  # no extension supplied
+        assert_array_equal(loaded.xaxis, straight_well.xaxis)
+        assert loaded.name == "wname"
+
+    def test_roundtrip_preserves_axes(self, straight_well, tmp_path):
+        fn = tmp_path / "r.npz"
+        straight_well.savez(str(fn))
+        loaded = DataG3D()
+        loaded.load_npz(str(fn))
+        assert_array_equal(loaded.xaxis, straight_well.xaxis)
+        assert_array_equal(loaded.yaxis, straight_well.yaxis)
+        assert_array_equal(loaded.zaxis, straight_well.zaxis)
+        assert_array_equal(loaded.data, straight_well.data)
+
+    @pytest.mark.parametrize("missing", ["data", "xaxis", "yaxis", "zaxis"])
+    def test_savez_raises_when_axis_missing(self, straight_well, tmp_path, missing):
+        setattr(straight_well, missing, None)
+        with pytest.raises(ValueError):
+            straight_well.savez(str(tmp_path / "fail.npz"))
+
+
+# --------------------------------------------------------------------------- #
+# info / str                                                                   #
+# --------------------------------------------------------------------------- #
+class TestInfo:
+    def test_info_str_unset(self):
+        s = DataG3D().get_info_str()
+        assert "DataG3D Object Summary: Unnamed" in s
+        assert "Data (MD): Not set" in s
+        assert "X Axis (xaxis): Not set" in s
+        assert "Y Axis (yaxis): Not set" in s
+        assert "Z Axis (zaxis): Not set" in s
+
+    def test_info_str_populated_small_axes(self, straight_well):
+        s = straight_well.get_info_str()
+        assert "DataG3D Object Summary: straight" in s
+        assert "Data (MD): Length=5" in s
+        assert "X Axis (xaxis): Length=5" in s
+        assert "Z Axis (zaxis): Length=5" in s
+        # Short axes still get an ellipsis appended.
+        assert "..." in s
+
+    def test_str_dunder_matches_info(self, straight_well):
+        assert str(straight_well) == straight_well.get_info_str()
+
+    def test_print_info_runs(self, straight_well, capsys):
+        straight_well.print_info()
+        assert "DataG3D Object Summary" in capsys.readouterr().out
+
+
+# --------------------------------------------------------------------------- #
+# plotting                                                                     #
+# --------------------------------------------------------------------------- #
+class TestPlot:
+    def test_plot_line_returns_list_of_lines(self, straight_well):
+        artist = straight_well.plot()
+        assert isinstance(artist, list)
+        assert isinstance(artist[0], Line2D)
+        plt.close("all")
+
+    def test_plot_scatter_on_provided_axes(self, straight_well):
+        fig = plt.figure()
+        ax = fig.add_subplot(111, projection="3d")
+        artist = straight_well.plot(ax=ax, mode="scatter")
+        # mpl 3D scatter returns a Path3DCollection.
+        assert type(artist).__name__ == "Path3DCollection"
+        plt.close("all")
+
+    def test_plot_sets_default_axis_labels(self, straight_well):
+        fig = plt.figure()
+        ax = fig.add_subplot(111, projection="3d")
+        straight_well.plot(ax=ax)
+        assert ax.get_xlabel() == "X coordinate"
+        assert ax.get_ylabel() == "Y coordinate"
+        assert ax.get_zlabel() == "Z coordinate"
+        plt.close("all")
+
+    def test_plot_custom_labels_and_title(self, straight_well):
+        fig = plt.figure()
+        ax = fig.add_subplot(111, projection="3d")
+        straight_well.plot(
+            ax=ax, xlabel="EW", ylabel="NS", zlabel="TVD", title="My Well"
+        )
+        assert ax.get_xlabel() == "EW"
+        assert ax.get_zlabel() == "TVD"
+        assert ax.get_title() == "My Well"
+        plt.close("all")
+
+    def test_plot_creates_new_figure_when_ax_none(self, straight_well):
+        # With ax=None a new 3D figure is created; default title uses the name.
+        n_before = len(plt.get_fignums())
+        artist = straight_well.plot()
+        assert isinstance(artist[0], Line2D)
+        assert len(plt.get_fignums()) == n_before + 1
+        plt.close("all")
+
+    def test_plot_invalid_mode_raises(self, straight_well):
+        fig = plt.figure()
+        ax = fig.add_subplot(111, projection="3d")
+        with pytest.raises(ValueError):
+            straight_well.plot(ax=ax, mode="bogus")
+        plt.close("all")
+
+    def test_plot_guard_when_axes_unset(self):
+        g = DataG3D()
+        with pytest.raises(ValueError):
+            g.plot()
+        assert any(r["level"] == "ERROR" for r in g.history.records)
+
+    def test_plot_logs_history_record(self, straight_well):
+        fig = plt.figure()
+        ax = fig.add_subplot(111, projection="3d")
+        before = len(straight_well.history.records)
+        straight_well.plot(ax=ax)
+        assert len(straight_well.history.records) == before + 1
+        plt.close("all")
+
+
+# --------------------------------------------------------------------------- #
+# G3DMeasuredDepth subclass                                                    #
+# --------------------------------------------------------------------------- #
+class TestG3DMeasuredDepth:
+    def test_is_subclass_of_datag3d(self):
+        md = G3DMeasuredDepth()
+        assert isinstance(md, DataG3D)
+
+    def test_inherits_calculate_md(self):
+        md = G3DMeasuredDepth()
+        md.xaxis = np.array([0.0, 3.0])
+        md.yaxis = np.array([0.0, 4.0])
+        md.zaxis = np.array([0.0, 0.0])
+        md.data = np.zeros(2)
+        assert_allclose(md.calculate_md(), [0.0, 5.0])
+
+    def test_stub_methods_return_none(self):
+        # These are currently unimplemented placeholders.
+        md = G3DMeasuredDepth()
+        assert md.plot_loc() is None
+        assert md.get_spatial_coor(123.0) is None

--- a/tests/test_history_utils.py
+++ b/tests/test_history_utils.py
@@ -1,0 +1,188 @@
+# Characterization tests for fiberis.utils.history_utils.InfoManagementSystem.
+#
+# Pins the current behavior of the operation-logging system: record storage,
+# level normalization, filtering, printing, file persistence, and dunders.
+
+import datetime
+import os
+
+import pytest
+
+from fiberis.utils.history_utils import InfoManagementSystem
+
+
+@pytest.fixture
+def ims():
+    return InfoManagementSystem()
+
+
+# ---------------------------------------------------------------------------
+# Construction / basic storage
+# ---------------------------------------------------------------------------
+
+def test_starts_empty(ims):
+    assert ims.records == []
+    assert ims.get_records() == []
+
+
+def test_add_record_default_level(ims):
+    ims.add_record("hello")
+    assert len(ims.records) == 1
+    rec = ims.records[0]
+    assert rec["description"] == "hello"
+    assert rec["level"] == "INFO"
+    assert isinstance(rec["timestamp"], datetime.datetime)
+
+
+def test_add_record_level_uppercased(ims):
+    ims.add_record("a", level="warning")
+    ims.add_record("b", level="Error")
+    assert ims.records[0]["level"] == "WARNING"
+    assert ims.records[1]["level"] == "ERROR"
+
+
+def test_add_record_nonstring_description_coerced(ims):
+    ims.add_record(12345)
+    assert ims.records[0]["description"] == "12345"
+
+
+def test_add_record_nonstring_level_coerced_and_uppercased(ims):
+    ims.add_record("x", level=42)
+    # NOTE: non-string level path applies str(...).upper().
+    assert ims.records[0]["level"] == "42"
+
+
+def test_records_appended_in_order(ims):
+    ims.add_record("first")
+    ims.add_record("second")
+    ims.add_record("third")
+    descs = [r["description"] for r in ims.get_records()]
+    assert descs == ["first", "second", "third"]
+
+
+# ---------------------------------------------------------------------------
+# get_records / filtering
+# ---------------------------------------------------------------------------
+
+def test_get_records_returns_copy(ims):
+    ims.add_record("a")
+    got = ims.get_records()
+    got.append("garbage")
+    # Mutating the returned list must not affect internal storage.
+    assert len(ims.records) == 1
+
+
+def test_get_records_filter_by_level(ims):
+    ims.add_record("info1", level="INFO")
+    ims.add_record("warn1", level="WARNING")
+    ims.add_record("info2", level="INFO")
+    infos = ims.get_records(lambda r: r["level"] == "INFO")
+    assert len(infos) == 2
+    assert {r["description"] for r in infos} == {"info1", "info2"}
+
+
+def test_get_records_filter_no_match(ims):
+    ims.add_record("a", level="INFO")
+    assert ims.get_records(lambda r: r["level"] == "ERROR") == []
+
+
+# ---------------------------------------------------------------------------
+# print_records
+# ---------------------------------------------------------------------------
+
+def test_print_records_empty(ims, capsys):
+    ims.print_records()
+    out = capsys.readouterr().out
+    assert "No records to display." in out
+
+
+def test_print_records_format(ims, capsys):
+    ims.add_record("the message", level="WARNING")
+    ims.print_records()
+    out = capsys.readouterr().out
+    assert "[WARNING]" in out
+    assert "the message" in out
+
+
+def test_print_records_with_filter(ims, capsys):
+    ims.add_record("keep", level="ERROR")
+    ims.add_record("drop", level="INFO")
+    ims.print_records(lambda r: r["level"] == "ERROR")
+    out = capsys.readouterr().out
+    assert "keep" in out
+    assert "drop" not in out
+
+
+# ---------------------------------------------------------------------------
+# save_records_to_txt
+# ---------------------------------------------------------------------------
+
+def test_save_records_empty_returns_empty_string(ims, capsys):
+    result = ims.save_records_to_txt()
+    assert result == ""
+    assert "No records to save." in capsys.readouterr().out
+
+
+def test_save_records_to_directory(ims, tmp_path):
+    ims.add_record("saved message", level="INFO")
+    path = ims.save_records_to_txt(str(tmp_path))
+    assert path != ""
+    assert os.path.isfile(path)
+    assert os.path.dirname(path) == str(tmp_path)
+    content = open(path).read()
+    assert "saved message" in content
+    assert "Level:     INFO" in content
+    assert "-" * 50 in content
+
+
+def test_save_records_to_explicit_filepath(ims, tmp_path):
+    ims.add_record("explicit", level="DEBUG")
+    target = str(tmp_path / "my_log.txt")
+    path = ims.save_records_to_txt(target)
+    assert path == target
+    assert os.path.isfile(target)
+    assert "explicit" in open(target).read()
+
+
+def test_save_records_with_filter(ims, tmp_path):
+    ims.add_record("err", level="ERROR")
+    ims.add_record("inf", level="INFO")
+    target = str(tmp_path / "filtered.txt")
+    ims.save_records_to_txt(target, filter_fn=lambda r: r["level"] == "ERROR")
+    content = open(target).read()
+    assert "err" in content
+    assert "inf" not in content
+
+
+# ---------------------------------------------------------------------------
+# clear_records
+# ---------------------------------------------------------------------------
+
+def test_clear_records(ims):
+    ims.add_record("a")
+    ims.add_record("b")
+    ims.clear_records()
+    assert ims.records == []
+    assert ims.get_records() == []
+
+
+# ---------------------------------------------------------------------------
+# __repr__ / __str__
+# ---------------------------------------------------------------------------
+
+def test_repr(ims):
+    assert repr(ims) == "InfoManagementSystem(records_count=0)"
+    ims.add_record("a")
+    assert repr(ims) == "InfoManagementSystem(records_count=1)"
+
+
+def test_str_empty(ims):
+    assert str(ims) == "No records in history."
+
+
+def test_str_with_records(ims):
+    ims.add_record("hello world", level="INFO")
+    s = str(ims)
+    assert s.startswith("History Log (1 records):")
+    assert "[INFO]" in s
+    assert "hello world" in s

--- a/tests/test_io_core.py
+++ b/tests/test_io_core.py
@@ -1,0 +1,133 @@
+# Characterization tests for fiberis.io.core.DataIO.
+#
+# These lock in the current observable behavior of the abstract base reader
+# class (constructor-initialized attributes, the manual setters, and the
+# logging integration with InfoManagementSystem). They must remain GREEN
+# through a pure refactor.
+
+import datetime
+
+import numpy as np
+import pytest
+
+from fiberis.io import core
+from fiberis.utils.history_utils import InfoManagementSystem
+
+
+class _ConcreteIO(core.DataIO):
+    """Minimal concrete subclass so the ABC can be instantiated for testing."""
+
+    def read(self, **kwargs):  # pragma: no cover - trivial stub
+        return None
+
+    def write(self, filename, *args):  # pragma: no cover - trivial stub
+        return None
+
+    def to_analyzer(self):  # pragma: no cover - trivial stub
+        return None
+
+
+def test_dataio_is_abstract_cannot_instantiate_directly():
+    # DataIO declares abstract methods read/write/to_analyzer, so direct
+    # instantiation must raise TypeError.
+    with pytest.raises(TypeError):
+        core.DataIO()
+
+
+def test_constructor_initializes_all_axes_to_none():
+    obj = _ConcreteIO()
+    assert obj.daxis is None
+    assert obj.taxis is None
+    assert obj.data is None
+    assert obj.start_time is None
+    assert obj.filename is None
+    # 3D geometry handling attributes
+    assert obj.xaxis is None
+    assert obj.yaxis is None
+    assert obj.zaxis is None
+
+
+def test_constructor_creates_log_system():
+    obj = _ConcreteIO()
+    assert isinstance(obj.log_system, InfoManagementSystem)
+    # A fresh log system starts with no records.
+    assert obj.log_system.get_records() == []
+
+
+def test_set_daxis_sets_value_and_records_log():
+    obj = _ConcreteIO()
+    daxis = np.array([0.0, 1.0, 2.0])
+    obj.set_daxis(daxis)
+    np.testing.assert_array_equal(obj.daxis, daxis)
+
+    records = obj.log_system.get_records()
+    assert len(records) == 1
+    assert records[0]["description"] == "daxis is set."
+    assert records[0]["level"] == "INFO"
+
+
+def test_set_taxis_sets_value_and_records_log():
+    obj = _ConcreteIO()
+    taxis = np.linspace(0, 10, 11)
+    obj.set_taxis(taxis)
+    np.testing.assert_array_equal(obj.taxis, taxis)
+    records = obj.log_system.get_records()
+    assert records[-1]["description"] == "taxis is set."
+
+
+def test_set_data_sets_value_and_records_log():
+    obj = _ConcreteIO()
+    data = np.arange(6).reshape(2, 3)
+    obj.set_data(data)
+    np.testing.assert_array_equal(obj.data, data)
+    records = obj.log_system.get_records()
+    assert records[-1]["description"] == "data is set."
+
+
+def test_set_start_time_sets_value_and_records_log(sample_start_time):
+    obj = _ConcreteIO()
+    obj.set_start_time(sample_start_time)
+    assert obj.start_time == sample_start_time
+    records = obj.log_system.get_records()
+    assert records[-1]["description"] == "start_time is set."
+
+
+def test_record_log_joins_args_with_spaces():
+    obj = _ConcreteIO()
+    obj.record_log("hello", "world", 42)
+    records = obj.log_system.get_records()
+    assert records[-1]["description"] == "hello world 42"
+    assert records[-1]["level"] == "INFO"
+
+
+def test_record_log_respects_explicit_level():
+    obj = _ConcreteIO()
+    obj.record_log("a problem", level="ERROR")
+    records = obj.log_system.get_records()
+    assert records[-1]["level"] == "ERROR"
+
+
+def test_record_log_record_has_timestamp_datetime():
+    obj = _ConcreteIO()
+    obj.record_log("ts check")
+    record = obj.log_system.get_records()[-1]
+    assert isinstance(record["timestamp"], datetime.datetime)
+
+
+def test_multiple_setters_accumulate_records_in_order():
+    obj = _ConcreteIO()
+    obj.set_daxis(np.array([1.0]))
+    obj.set_taxis(np.array([2.0]))
+    obj.set_data(np.array([3.0]))
+    descriptions = [r["description"] for r in obj.log_system.get_records()]
+    assert descriptions == ["daxis is set.", "taxis is set.", "data is set."]
+
+
+def test_print_log_runs_without_error(capsys):
+    obj = _ConcreteIO()
+    obj.record_log("message for printing")
+    obj.print_log()
+    captured = capsys.readouterr()
+    # We only pin that it produced output mentioning the recorded message;
+    # exact formatting is owned by InfoManagementSystem.
+    assert "message for printing" in captured.out

--- a/tests/test_io_readers.py
+++ b/tests/test_io_readers.py
@@ -1,0 +1,392 @@
+# Characterization tests for the fiberis.io reader_*.py modules.
+#
+# Strategy:
+#   * Readers whose raw input format matches a bundled fixture are exercised on
+#     the real read path and their output shapes/dtypes/values are pinned.
+#       - reader_hfts2_h5.HFTS2DAS2D        -> examples/data/2d/original_data/*.h5
+#       - reader_mariner_dssh5.MarinerDSS2D -> same h5 (read currently FAILS; pinned)
+#       - reader_MOOSEcsv_pp1d.MOOSEcsv_pp1d -> synthesized MOOSE CSV
+#       - reader_moose_ps.MOOSEPointSamplerReader -> synthesized MOOSE CSV
+#       - reader_moose_vpp.MOOSEVectorPostProcessorReader -> synthesized VPP CSVs
+#   * Readers that require vendor raw data we do not have get an import/smoke
+#     test plus a skip for the read path.
+#
+# These must remain GREEN through a pure refactor.
+
+import datetime
+import importlib
+import os
+
+import numpy as np
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _h5_dir(examples_data_dir):
+    return os.path.join(examples_data_dir, "2d", "original_data")
+
+
+# ---------------------------------------------------------------------------
+# HFTS2 DAS h5 reader -- REAL DATA read path
+# ---------------------------------------------------------------------------
+
+class TestHFTS2DAS2DRealData:
+    def _read(self, examples_data_dir):
+        from fiberis.io.reader_hfts2_h5 import HFTS2DAS2D
+
+        reader = HFTS2DAS2D()
+        reader.read(_h5_dir(examples_data_dir))
+        return reader
+
+    def test_to_analyzer_shapes_and_dtype(self, examples_data_dir):
+        reader = self._read(examples_data_dir)
+        ana = reader.to_analyzer()
+        # DSS2D analyzer object.
+        assert type(ana).__name__ == "DSS2D"
+        # 9 h5 files, each (6100, 30); merged along time -> (6100, 258).
+        assert ana.data.shape == (6100, 258)
+        assert ana.data.dtype == np.int32
+        assert ana.daxis.shape == (6100,)
+        assert ana.taxis.shape == (258,)
+
+    def test_daxis_from_depth_table(self, examples_data_dir):
+        ana = self._read(examples_data_dir).to_analyzer()
+        # daxis comes from the calibrated HFTS2 depth table, not the h5 file.
+        np.testing.assert_allclose(ana.daxis[0], -318.93235)
+        np.testing.assert_allclose(ana.daxis[-1], 5881.690674)
+
+    def test_taxis_is_relative_starting_at_zero(self, examples_data_dir):
+        ana = self._read(examples_data_dir).to_analyzer()
+        assert ana.taxis[0] == 0.0
+        np.testing.assert_allclose(ana.taxis[-1], 2587.14)
+
+    def test_start_time_is_utc_from_first_chunk(self, examples_data_dir):
+        ana = self._read(examples_data_dir).to_analyzer()
+        assert ana.start_time == datetime.datetime(
+            2019, 3, 28, 16, 4, 19, 700000, tzinfo=datetime.timezone.utc
+        )
+
+    def test_pinned_data_values(self, examples_data_dir):
+        ana = self._read(examples_data_dir).to_analyzer()
+        assert ana.data[0, 0] == 49986
+        assert int(ana.data.sum()) == -3576841782
+
+    def test_read_missing_folder_returns_quietly(self, tmp_path):
+        from fiberis.io.reader_hfts2_h5 import HFTS2DAS2D
+
+        reader = HFTS2DAS2D()
+        # No .h5 files -> reader prints a warning and returns; temp_dssobject
+        # stays the empty default DSS2D constructed in __init__.
+        reader.read(str(tmp_path))
+        assert reader.temp_dssobject.data is None
+
+
+def test_hfts2curve_is_constructible_but_unimplemented():
+    # HFTS2CURVE.read/write/to_analyzer are stubs (pass). Pin that the class
+    # is importable/constructible and that read() returns None.
+    from fiberis.io.reader_hfts2_h5 import HFTS2CURVE
+
+    curve = HFTS2CURVE()
+    assert curve.read("anything", "var") is None
+    assert curve.to_analyzer() is None
+
+
+# ---------------------------------------------------------------------------
+# Mariner single-file DSS h5 reader -- REAL DATA read path (currently fails)
+# ---------------------------------------------------------------------------
+
+class TestMarinerDSS2DRealData:
+    def _h5_file(self, examples_data_dir):
+        return os.path.join(_h5_dir(examples_data_dir), "sensor_2019-03-28T160419Z.h5")
+
+    def test_read_raises_on_missing_start_time_metadata(self, examples_data_dir):
+        # NOTE: possible bug / data limitation. read_h5 returns start_time=None
+        # for these HFTS-style h5 files (no 'stamps' key), and MarinerDSS2D.read
+        # unconditionally calls start_time.decode(), raising AttributeError.
+        from fiberis.io.reader_mariner_dssh5 import MarinerDSS2D
+
+        reader = MarinerDSS2D()
+        with pytest.raises(AttributeError):
+            reader.read(self._h5_file(examples_data_dir))
+
+    def test_partial_state_before_failure(self, examples_data_dir):
+        # Before the start_time conversion fails, taxis/daxis/data are assigned.
+        from fiberis.io.reader_mariner_dssh5 import MarinerDSS2D
+
+        reader = MarinerDSS2D()
+        try:
+            reader.read(self._h5_file(examples_data_dir))
+        except AttributeError:
+            pass
+        assert reader.data is not None
+        assert reader.data.shape == (6100, 30)
+        assert reader.taxis is not None
+        assert reader.taxis[0] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# MOOSE CSV 1D reader -- synthesized faithful CSV
+# ---------------------------------------------------------------------------
+
+def _write_moose_point_sampler_csv(path):
+    """A MOOSE PointSampler-style CSV: a 'time' column plus variable columns."""
+    path.write_text(
+        "time,pp_mon1,pp_mon2\n"
+        "0.0,10.0,20.0\n"
+        "1.0,11.0,21.0\n"
+        "2.0,12.0,22.0\n"
+    )
+    return str(path)
+
+
+class TestMOOSEcsvPP1D:
+    def test_list_available_keys(self, tmp_path):
+        from fiberis.io.reader_MOOSEcsv_pp1d import MOOSEcsv_pp1d
+
+        csv = _write_moose_point_sampler_csv(tmp_path / "sampler_out.csv")
+        keys = MOOSEcsv_pp1d().list_available_keys(csv)
+        # 'time' is excluded from the returned keys.
+        assert keys == ["pp_mon1", "pp_mon2"]
+
+    def test_read_selects_named_column(self, tmp_path):
+        from fiberis.io.reader_MOOSEcsv_pp1d import MOOSEcsv_pp1d
+
+        csv = _write_moose_point_sampler_csv(tmp_path / "sampler_out.csv")
+        reader = MOOSEcsv_pp1d()
+        reader.read(csv, key="pp_mon2")
+        np.testing.assert_array_equal(reader.taxis, [0.0, 1.0, 2.0])
+        np.testing.assert_array_equal(reader.data, [20.0, 21.0, 22.0])
+        assert reader.label == "pp_mon2"
+
+    def test_default_start_time(self, tmp_path):
+        from fiberis.io.reader_MOOSEcsv_pp1d import MOOSEcsv_pp1d
+
+        # start_time defaults to 2024-01-01 (arbitrary simulation time).
+        assert MOOSEcsv_pp1d().start_time == datetime.datetime(2024, 1, 1)
+
+    def test_read_missing_key_raises(self, tmp_path):
+        from fiberis.io.reader_MOOSEcsv_pp1d import MOOSEcsv_pp1d
+
+        csv = _write_moose_point_sampler_csv(tmp_path / "sampler_out.csv")
+        with pytest.raises(ValueError):
+            MOOSEcsv_pp1d().read(csv, key="does_not_exist")
+
+    def test_read_none_key_raises(self, tmp_path):
+        from fiberis.io.reader_MOOSEcsv_pp1d import MOOSEcsv_pp1d
+
+        csv = _write_moose_point_sampler_csv(tmp_path / "sampler_out.csv")
+        with pytest.raises(ValueError):
+            MOOSEcsv_pp1d().read(csv, key=None)
+
+    def test_to_analyzer(self, tmp_path):
+        from fiberis.io.reader_MOOSEcsv_pp1d import MOOSEcsv_pp1d
+
+        csv = _write_moose_point_sampler_csv(tmp_path / "sampler_out.csv")
+        reader = MOOSEcsv_pp1d()
+        reader.read(csv, key="pp_mon1")
+        ana = reader.to_analyzer()
+        assert type(ana).__name__ == "Data1D"
+        assert ana.name == "pp_mon1"
+        np.testing.assert_array_equal(ana.data, [10.0, 11.0, 12.0])
+
+    def test_write_then_roundtrip_npz(self, tmp_path):
+        from fiberis.io.reader_MOOSEcsv_pp1d import MOOSEcsv_pp1d
+
+        csv = _write_moose_point_sampler_csv(tmp_path / "sampler_out.csv")
+        reader = MOOSEcsv_pp1d()
+        reader.read(csv, key="pp_mon2")
+        out = str(tmp_path / "out")  # no .npz extension -> appended
+        reader.write(out)
+        loaded = np.load(out + ".npz", allow_pickle=True)
+        np.testing.assert_array_equal(loaded["data"], [20.0, 21.0, 22.0])
+        assert str(loaded["label"]) == "pp_mon2"
+
+
+# ---------------------------------------------------------------------------
+# MOOSE Point Sampler reader (folder-based auto-discovery)
+# ---------------------------------------------------------------------------
+
+class TestMOOSEPointSamplerReader:
+    def test_read_auto_discovers_and_loads(self, tmp_path):
+        from fiberis.io.reader_moose_ps import MOOSEPointSamplerReader
+
+        _write_moose_point_sampler_csv(tmp_path / "sampler_out.csv")
+        reader = MOOSEPointSamplerReader()
+        reader.read(str(tmp_path), variable_index=1)
+        np.testing.assert_array_equal(reader.taxis, [0.0, 1.0, 2.0])
+        np.testing.assert_array_equal(reader.data, [10.0, 11.0, 12.0])
+        assert reader.variable_name == "pp_mon1"
+
+    def test_get_max_index(self, tmp_path):
+        from fiberis.io.reader_moose_ps import MOOSEPointSamplerReader
+
+        _write_moose_point_sampler_csv(tmp_path / "sampler_out.csv")
+        # 2 data columns -> max index 2.
+        assert MOOSEPointSamplerReader().get_max_index(str(tmp_path)) == 2
+
+    def test_read_ambiguous_when_two_unnumbered_csvs(self, tmp_path):
+        from fiberis.io.reader_moose_ps import MOOSEPointSamplerReader
+
+        _write_moose_point_sampler_csv(tmp_path / "a.csv")
+        _write_moose_point_sampler_csv(tmp_path / "b.csv")
+        # More than one candidate sampler file -> FileNotFoundError.
+        with pytest.raises(FileNotFoundError):
+            MOOSEPointSamplerReader().read(str(tmp_path))
+
+    def test_read_out_of_bounds_index_raises(self, tmp_path):
+        from fiberis.io.reader_moose_ps import MOOSEPointSamplerReader
+
+        _write_moose_point_sampler_csv(tmp_path / "sampler_out.csv")
+        # The internal IndexError is caught and re-raised as ValueError by the
+        # broad except in read().
+        with pytest.raises(ValueError):
+            MOOSEPointSamplerReader().read(str(tmp_path), variable_index=99)
+
+    def test_to_analyzer(self, tmp_path):
+        from fiberis.io.reader_moose_ps import MOOSEPointSamplerReader
+
+        _write_moose_point_sampler_csv(tmp_path / "sampler_out.csv")
+        reader = MOOSEPointSamplerReader()
+        reader.read(str(tmp_path), variable_index=2)
+        ana = reader.to_analyzer()
+        assert type(ana).__name__ == "Data1D_MOOSEps"
+        assert ana.name == "pp_mon2"
+        np.testing.assert_array_equal(ana.data, [20.0, 21.0, 22.0])
+
+
+# ---------------------------------------------------------------------------
+# MOOSE VectorPostProcessor reader (CSV series)
+# ---------------------------------------------------------------------------
+
+def _write_moose_vpp_series(folder):
+    """A MOOSE VectorPostProcessor-style series.
+
+    The time-series file is the single non-numbered CSV; each numbered file
+    holds one timestep with columns [id, var, x, y, z].
+    """
+    (folder / "run_out.csv").write_text("time\n0.0\n1.0\n2.0\n")
+    for i in range(3):
+        (folder / f"line_sampler_{i:04d}.csv").write_text(
+            "id,pressure,x,y,z\n"
+            f"0,{100.0 + i},0.0,0.0,0.0\n"
+            f"1,{200.0 + i},1.0,0.0,0.0\n"
+            f"2,{300.0 + i},2.0,0.0,0.0\n"
+        )
+
+
+class TestMOOSEVectorPostProcessorReader:
+    def test_get_max_indices(self, tmp_path):
+        from fiberis.io.reader_moose_vpp import MOOSEVectorPostProcessorReader
+
+        _write_moose_vpp_series(tmp_path)
+        # One sampler -> processor id 0; columns id,pressure,x,y,z (5) -> var idx 1.
+        assert MOOSEVectorPostProcessorReader().get_max_indices(str(tmp_path)) == (0, 1)
+
+    def test_read_assembles_space_by_time_matrix(self, tmp_path):
+        from fiberis.io.reader_moose_vpp import MOOSEVectorPostProcessorReader
+
+        _write_moose_vpp_series(tmp_path)
+        reader = MOOSEVectorPostProcessorReader()
+        reader.read(str(tmp_path), post_processor_id=0, variable_index=1)
+        np.testing.assert_array_equal(reader.taxis, [0.0, 1.0, 2.0])
+        # data is stacked along axis=1 -> (n_space, n_time) = (3, 3).
+        assert reader.data.shape == (3, 3)
+        np.testing.assert_array_equal(
+            reader.data,
+            [[100.0, 101.0, 102.0],
+             [200.0, 201.0, 202.0],
+             [300.0, 301.0, 302.0]],
+        )
+        assert reader.sampler_name == "line_sampler"
+        assert reader.variable_name == "pressure"
+
+    def test_daxis_is_cumulative_distance(self, tmp_path):
+        from fiberis.io.reader_moose_vpp import MOOSEVectorPostProcessorReader
+
+        _write_moose_vpp_series(tmp_path)
+        reader = MOOSEVectorPostProcessorReader()
+        reader.read(str(tmp_path))
+        # daxis = sqrt((x-x0)^2 + (y-y0)^2) with x=[0,1,2], y=0.
+        np.testing.assert_allclose(reader.daxis, [0.0, 1.0, 2.0])
+
+    def test_read_no_samplers_raises(self, tmp_path):
+        from fiberis.io.reader_moose_vpp import MOOSEVectorPostProcessorReader
+
+        (tmp_path / "run_out.csv").write_text("time\n0.0\n")
+        with pytest.raises(FileNotFoundError):
+            MOOSEVectorPostProcessorReader().read(str(tmp_path))
+
+    def test_to_analyzer(self, tmp_path):
+        from fiberis.io.reader_moose_vpp import MOOSEVectorPostProcessorReader
+
+        _write_moose_vpp_series(tmp_path)
+        reader = MOOSEVectorPostProcessorReader()
+        reader.read(str(tmp_path))
+        ana = reader.to_analyzer()
+        assert type(ana).__name__ == "Data2D"
+        assert ana.name == "line_sampler_pressure"
+
+
+# ---------------------------------------------------------------------------
+# Smoke / import tests for readers that need vendor raw data we do not have.
+# ---------------------------------------------------------------------------
+
+# (module_name, class_name) pairs that import cleanly and are constructible.
+_CONSTRUCTIBLE_VENDOR_READERS = [
+    ("reader_bearskin_injection", "BearskinInjection"),
+    ("reader_bearskin_pp1d", "BearskinPP1D"),
+    ("reader_gold4pb_3d", "Gold4PB3D"),
+    ("reader_gold4pb_projection", "Gold4PBProjection"),
+    ("reader_mariner_das2d", "MarinerDAS2D"),
+    ("reader_mariner_fiberdata_production_dat2d", "MarinerDSSdat2D"),
+    ("reader_mariner_pp1d", "MarinerPP1D"),
+    ("reader_mariner_pressureg1", "MarinerPressureG1"),
+    ("reader_moose_tensor_from_data2d", "MOOSETensorFromData2D"),
+    ("reader_moose_tensor_vpp", "MOOSETensorVPPReader"),
+]
+
+
+@pytest.mark.parametrize("module_name,class_name", _CONSTRUCTIBLE_VENDOR_READERS)
+def test_vendor_reader_importable_and_constructible(module_name, class_name):
+    module = importlib.import_module(f"fiberis.io.{module_name}")
+    cls = getattr(module, class_name)
+    instance = cls()
+    # All readers descend from DataIO and expose the standard attributes.
+    from fiberis.io.core import DataIO
+
+    assert isinstance(instance, DataIO)
+    assert hasattr(instance, "read")
+    pytest.skip(f"requires raw vendor data not bundled for {module_name}")
+
+
+def test_mariner_rfs_abandoned_is_abstract():
+    # NOTE: the 'abandoned' RFS reader does not implement the abstract
+    # to_analyzer() method, so it cannot be instantiated. Pin this current
+    # (intentionally abandoned) state.
+    from fiberis.io.reader_mariner_rfs_abandoned import Mariner2DRFS2D
+
+    with pytest.raises(TypeError):
+        Mariner2DRFS2D()
+    pytest.skip("reader_mariner_rfs_abandoned is abstract; requires raw vendor data not bundled")
+
+
+# These two modules currently fail to import because of missing names in the
+# fiberis.analyzer package. NOTE: possible bug -- the imported symbols
+# (DataG3D / Data1DGauge) are not exported. Pinned as expected failures.
+@pytest.mark.parametrize(
+    "module_name,missing_symbol",
+    [
+        ("reader_mariner_3d", "DataG3D"),
+        ("reader_mariner_gauge1d", "Data1DGauge"),
+    ],
+)
+def test_reader_with_broken_import(module_name, missing_symbol):
+    with pytest.raises(ImportError):
+        importlib.import_module(f"fiberis.io.{module_name}")
+    pytest.skip(
+        f"{module_name} currently fails to import (missing {missing_symbol}); "
+        "requires raw vendor data not bundled anyway"
+    )

--- a/tests/test_io_readers.py
+++ b/tests/test_io_readers.py
@@ -373,20 +373,24 @@ def test_mariner_rfs_abandoned_is_abstract():
     pytest.skip("reader_mariner_rfs_abandoned is abstract; requires raw vendor data not bundled")
 
 
-# These two modules currently fail to import because of missing names in the
-# fiberis.analyzer package. NOTE: possible bug -- the imported symbols
-# (DataG3D / Data1DGauge) are not exported. Pinned as expected failures.
+# These two modules previously failed to import because they imported a class
+# as if it were a submodule (DataG3D from Geometry3D, Data1DGauge from Data1D).
+# Fixed in docs/modernization_notes.md bugs #2/#3 -- now they import and the
+# reader classes are constructible DataIO subclasses. The raw read() path still
+# needs vendor data we do not bundle.
 @pytest.mark.parametrize(
-    "module_name,missing_symbol",
+    "module_name,class_name",
     [
-        ("reader_mariner_3d", "DataG3D"),
-        ("reader_mariner_gauge1d", "Data1DGauge"),
+        ("reader_mariner_3d", "Mariner3D"),
+        ("reader_mariner_gauge1d", "MarinerGauge1D"),
     ],
 )
-def test_reader_with_broken_import(module_name, missing_symbol):
-    with pytest.raises(ImportError):
-        importlib.import_module(f"fiberis.io.{module_name}")
-    pytest.skip(
-        f"{module_name} currently fails to import (missing {missing_symbol}); "
-        "requires raw vendor data not bundled anyway"
-    )
+def test_previously_broken_reader_now_imports(module_name, class_name):
+    module = importlib.import_module(f"fiberis.io.{module_name}")
+    cls = getattr(module, class_name)
+    instance = cls()
+    from fiberis.io.core import DataIO
+
+    assert isinstance(instance, DataIO)
+    assert hasattr(instance, "read")
+    pytest.skip(f"requires raw vendor data not bundled for {module_name}")

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -1,0 +1,116 @@
+# Characterization tests for fiberis.utils.io_utils.
+
+import h5py
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+from fiberis.utils import io_utils as io
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: write small HDF5 / csvh files into tmp_path
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def das_h5(tmp_path):
+    """An HDF5 file using the simple ('data', 'depth', ...) key set."""
+    fn = str(tmp_path / "das.h5")
+    with h5py.File(fn, "w") as f:
+        f.create_dataset("data", data=np.arange(12).reshape(3, 4).astype(float))
+        f.create_dataset("depth", data=np.array([1.0, 2.0, 3.0]))
+        f.create_dataset("stamps_unix", data=np.array([100.0, 101.0, 102.0]))
+        f.create_dataset("stamps", data=np.array([1000.0, 1001.0]))
+    return fn
+
+
+# ---------------------------------------------------------------------------
+# read_h5
+# ---------------------------------------------------------------------------
+
+def test_read_h5_simple_keys(das_h5):
+    data, daxis, taxis, start_time = io.read_h5(das_h5)
+    assert data.shape == (3, 4)
+    npt.assert_array_equal(daxis, [1.0, 2.0, 3.0])
+    npt.assert_array_equal(taxis, [100.0, 101.0, 102.0])
+    # start_time taken as the FIRST element of the 'stamps' dataset.
+    npt.assert_allclose(start_time, 1000.0, atol=1e-12)
+
+
+def test_read_h5_missing_keys_returns_none(tmp_path):
+    fn = str(tmp_path / "empty.h5")
+    with h5py.File(fn, "w") as f:
+        f.create_dataset("foo", data=np.array([1.0, 2.0]))
+    data, daxis, taxis, start_time = io.read_h5(fn)
+    assert data is None
+    assert daxis is None
+    assert taxis is None
+    assert start_time is None
+
+
+def test_read_h5_nested_acquisition_keys(tmp_path):
+    fn = str(tmp_path / "nested.h5")
+    with h5py.File(fn, "w") as f:
+        grp = f.create_group("Acquisition/Raw[0]")
+        grp.create_dataset("RawData", data=np.ones((2, 2)))
+        grp.create_dataset("RawDataTime", data=np.array([1.0, 2.0]))
+    data, daxis, taxis, start_time = io.read_h5(fn)
+    npt.assert_array_equal(data, np.ones((2, 2)))
+    assert daxis is None  # no 'depth' key
+    npt.assert_array_equal(taxis, [1.0, 2.0])
+
+
+# ---------------------------------------------------------------------------
+# load_h5_by_group_name
+# ---------------------------------------------------------------------------
+
+def test_load_h5_by_group_name_found(das_h5):
+    out = io.load_h5_by_group_name(das_h5, "data")
+    assert out.shape == (3, 4)
+
+
+def test_load_h5_by_group_name_missing_returns_empty(das_h5, capsys):
+    out = io.load_h5_by_group_name(das_h5, "does_not_exist")
+    assert isinstance(out, np.ndarray)
+    assert out.size == 0
+    assert "not found" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# list_h5_keys
+# ---------------------------------------------------------------------------
+
+def test_list_h5_keys(das_h5):
+    keys = io.list_h5_keys(das_h5)
+    assert sorted(keys) == ["data", "depth", "stamps", "stamps_unix"]
+
+
+# ---------------------------------------------------------------------------
+# load_hfts2_depthtable
+# ---------------------------------------------------------------------------
+
+def test_load_hfts2_depthtable(tmp_path, capsys):
+    fn = tmp_path / "dt.csvh"
+    fn.write_text(
+        "# comment\n"
+        "~DATA\n"
+        "header1\n"
+        "header2\n"
+        "1,-317.911398\n"
+        "2,-317.0\n"
+        "3,bad\n"
+        "4,-315.5\n"
+    )
+    depths = io.load_hfts2_depthtable(str(fn))
+    # Two header lines after ~DATA are skipped; the unparseable 'bad' row is
+    # dropped with a warning, so only three valid depths remain.
+    npt.assert_allclose(depths, [-317.911398, -317.0, -315.5], atol=1e-6)
+    assert "Could not parse" in capsys.readouterr().out
+
+
+def test_load_hfts2_depthtable_no_data_section(tmp_path):
+    fn = tmp_path / "nodata.csvh"
+    fn.write_text("# only comments\n# nothing else\n")
+    depths = io.load_hfts2_depthtable(str(fn))
+    assert isinstance(depths, np.ndarray)
+    assert depths.size == 0

--- a/tests/test_mesh_utils.py
+++ b/tests/test_mesh_utils.py
@@ -1,0 +1,96 @@
+# Characterization tests for fiberis.utils.mesh_utils.
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+from fiberis.utils import mesh_utils as mu
+
+
+# ---------------------------------------------------------------------------
+# refine_mesh
+# ---------------------------------------------------------------------------
+
+def test_refine_mesh_golden():
+    x = np.arange(0, 11, dtype=float)  # 0..10
+    out = mu.refine_mesh(x, (3, 6), 2)
+    expected = [
+        0.0, 1.0, 2.0, 3.0,
+        3.375, 3.75, 4.125, 4.5, 4.875, 5.25, 5.625, 6.0,
+        7.0, 8.0, 9.0, 10.0,
+    ]
+    npt.assert_allclose(out, expected, atol=1e-9)
+
+
+def test_refine_mesh_factor3():
+    x = np.linspace(0, 10, 11)
+    out = mu.refine_mesh(x, (2.0, 4.0), 3)
+    assert len(out) == 18
+    npt.assert_allclose(out[0], 0.0, atol=1e-9)
+    npt.assert_allclose(out[-1], 10.0, atol=1e-9)
+    # Refined section between 2 and 4 inclusive.
+    assert np.all(np.diff(out) >= -1e-12)  # sorted ascending
+
+
+def test_refine_mesh_sorted_and_includes_endpoints():
+    x = np.linspace(0, 100, 21)
+    out = mu.refine_mesh(x, (20, 40), 5)
+    assert np.all(np.diff(out) >= 0)
+    assert out[0] == x[0]
+    assert out[-1] == x[-1]
+
+
+def test_refine_mesh_non_ndarray_raises():
+    with pytest.raises(ValueError):
+        mu.refine_mesh([0, 1, 2], (0, 1), 2)
+
+
+def test_refine_mesh_bad_range_raises():
+    x = np.arange(10.0)
+    with pytest.raises(ValueError):
+        mu.refine_mesh(x, (5, 3), 2)  # start >= end
+    with pytest.raises(ValueError):
+        mu.refine_mesh(x, (1, 2, 3), 2)  # wrong length
+
+
+def test_refine_mesh_bad_factor_raises():
+    x = np.arange(10.0)
+    with pytest.raises(ValueError):
+        mu.refine_mesh(x, (1, 5), 0)
+
+
+# ---------------------------------------------------------------------------
+# locate
+# ---------------------------------------------------------------------------
+
+def test_locate_nearest():
+    ind, val = mu.locate(np.array([0.0, 1.0, 2.0, 3.0, 4.0]), 2.6)
+    assert ind == 3
+    npt.assert_allclose(val, 3.0, atol=1e-12)
+
+
+def test_locate_beyond_range_clamps_to_nearest():
+    ind, val = mu.locate(np.array([10.0, 20.0, 30.0]), 100)
+    assert ind == 2
+    npt.assert_allclose(val, 30.0, atol=1e-12)
+
+
+def test_locate_exact():
+    ind, val = mu.locate(np.array([0.0, 5.0, 10.0]), 5.0)
+    assert ind == 1
+    assert val == 5.0
+
+
+def test_locate_non_ndarray_raises():
+    with pytest.raises(ValueError):
+        mu.locate([1, 2, 3], 2)
+
+
+def test_locate_empty_raises():
+    with pytest.raises(ValueError):
+        mu.locate(np.array([]), 1.0)
+
+
+def test_locate_non_scalar_raises():
+    with pytest.raises(ValueError):
+        mu.locate(np.array([1.0, 2.0]), np.array([1.0, 2.0]))

--- a/tests/test_moose_config.py
+++ b/tests/test_moose_config.py
@@ -1,0 +1,305 @@
+# Characterization tests for fiberis.moose.config
+#
+# Golden-master tests pinning the CURRENT defaults and serialization behavior of
+# the config dataclasses / parameter blocks. Values were obtained by RUNNING the
+# code. Tests must stay GREEN through a pure refactor.
+
+import numpy as np
+import pytest
+
+from fiberis.moose.config import (
+    ZoneMaterialProperties,
+    InitialConditionConfig,
+    MatrixConfig,
+    HydraulicFractureConfig,
+    SRVConfig,
+    CasingLayerConfig,
+    CasingConfig,
+    IndicatorConfig,
+    MarkerConfig,
+    AdaptivityConfig,
+    PostprocessorConfigBase,
+    PointValueSamplerConfig,
+    LineValueSamplerConfig,
+    PostprocessorConfig,
+    SimpleFluidPropertiesConfig,
+    TimeStepperFunctionConfig,
+    AdaptiveTimeStepperConfig,
+    TimeSequenceStepper,
+)
+from fiberis.analyzer.Data1D.core1D import Data1D
+
+
+# --- ZoneMaterialProperties -----------------------------------------------
+
+def test_zone_material_properties_defaults():
+    z = ZoneMaterialProperties(porosity=0.1, permeability=1e-15)
+    assert z.porosity == 0.1
+    assert z.permeability == 1e-15
+    assert z.youngs_modulus is None
+    assert z.poissons_ratio is None
+
+
+def test_zone_material_properties_full():
+    z = ZoneMaterialProperties(porosity=0.2, permeability="'1e-15 0 0'",
+                               youngs_modulus=3e10, poissons_ratio=0.25)
+    assert z.permeability == "'1e-15 0 0'"
+    assert z.youngs_modulus == 3e10
+    assert z.poissons_ratio == 0.25
+
+
+# --- InitialConditionConfig ------------------------------------------------
+
+def test_initial_condition_config_defaults():
+    ic = InitialConditionConfig(name="ic1", ic_type="ConstantIC", variable="pp")
+    assert ic.name == "ic1"
+    assert ic.ic_type == "ConstantIC"
+    assert ic.variable == "pp"
+    assert ic.params == {}
+
+
+def test_initial_condition_config_with_params():
+    ic = InitialConditionConfig(name="ic1", ic_type="ConstantIC",
+                                variable="pp", params={"value": 1.0})
+    assert ic.params == {"value": 1.0}
+
+
+# --- MatrixConfig ----------------------------------------------------------
+
+def test_matrix_config():
+    mats = ZoneMaterialProperties(porosity=0.05, permeability=1e-16)
+    m = MatrixConfig(name="matrix", materials=mats)
+    assert m.name == "matrix"
+    assert m.materials is mats
+    assert m.initial_conditions == []
+
+
+# --- HydraulicFractureConfig ----------------------------------------------
+
+def test_hydraulic_fracture_config_defaults():
+    mats = ZoneMaterialProperties(porosity=0.5, permeability=1e-10)
+    f = HydraulicFractureConfig(name="Frac1", length=200, height=0.2,
+                                center_x=500, center_y=250, materials=mats)
+    assert f.name == "Frac1"
+    assert f.length == 200
+    assert f.height == 0.2
+    assert f.center_x == 500
+    assert f.center_y == 250
+    assert f.orientation_angle == 0.0
+    assert f.mesh_length_param is None
+    assert f.mesh_height_param is None
+    assert f.initial_conditions == []
+
+
+def test_hydraulic_fracture_config_nonzero_orientation_prints(capsys):
+    mats = ZoneMaterialProperties(porosity=0.5, permeability=1e-10)
+    HydraulicFractureConfig(name="F", length=1, height=1, center_x=0,
+                            center_y=0, materials=mats, orientation_angle=30.0)
+    out = capsys.readouterr().out
+    assert "non-zero orientation_angle" in out
+
+
+# --- SRVConfig -------------------------------------------------------------
+
+def test_srv_config():
+    mats = ZoneMaterialProperties(porosity=0.1, permeability=1e-13)
+    s = SRVConfig(name="SRV1", length=300, height=80, center_x=500,
+                  center_y=250, materials=mats)
+    assert s.name == "SRV1"
+    assert s.length == 300
+    assert s.height == 80
+    assert s.initial_conditions == []
+    assert s.mesh_length_param is None
+
+
+# --- Casing configs --------------------------------------------------------
+
+def test_casing_layer_config():
+    mats = ZoneMaterialProperties(porosity=0.1, permeability=1e-15)
+    layer = CasingLayerConfig(name="sandstone", height=10.0, materials=mats)
+    assert layer.name == "sandstone"
+    assert layer.height == 10.0
+    assert layer.materials is mats
+
+
+def test_casing_config():
+    mats = ZoneMaterialProperties(porosity=0.1, permeability=1e-15)
+    layers = [CasingLayerConfig(name="l1", height=5.0, materials=mats),
+              CasingLayerConfig(name="l2", height=7.0, materials=mats)]
+    c = CasingConfig(name="casing", layers=layers,
+                     injection_well_name="well", injection_well_x_coord=50.0)
+    assert c.name == "casing"
+    assert len(c.layers) == 2
+    assert c.injection_well_name == "well"
+    assert c.injection_well_x_coord == 50.0
+
+
+# --- Adaptivity configs ----------------------------------------------------
+
+def test_indicator_and_marker_config():
+    ind = IndicatorConfig(name="ind", type="GradientJumpIndicator",
+                          params={"variable": "pp"})
+    mk = MarkerConfig(name="mk", type="ErrorFractionMarker",
+                      params={"refine": 0.3})
+    assert ind.name == "ind"
+    assert ind.type == "GradientJumpIndicator"
+    assert ind.params == {"variable": "pp"}
+    assert mk.params == {"refine": 0.3}
+
+
+def test_adaptivity_config_defaults_and_adders():
+    a = AdaptivityConfig(marker_to_use="m", steps=2)
+    assert a.marker_to_use == "m"
+    assert a.steps == 2
+    assert a.indicators == []
+    assert a.markers == []
+
+    ind = IndicatorConfig(name="i", type="T", params={})
+    mk = MarkerConfig(name="m", type="T", params={})
+    a.add_indicator(ind)
+    a.add_marker(mk)
+    assert a.indicators == [ind]
+    assert a.markers == [mk]
+
+
+def test_adaptivity_config_add_wrong_type_raises():
+    a = AdaptivityConfig(marker_to_use="m", steps=1)
+    with pytest.raises(TypeError):
+        a.add_indicator("not an indicator")
+    with pytest.raises(TypeError):
+        a.add_marker("not a marker")
+
+
+# --- Postprocessor configs -------------------------------------------------
+
+def test_postprocessor_config_base_default_execute_on():
+    b = PostprocessorConfigBase(name="b", pp_type="X")
+    # NOTE: mutable default argument; current default value pinned here.
+    assert b.execute_on == ['initial', 'timestep_end', 'final']
+    assert b.variable is None
+    assert b.variables is None
+    assert b.other_params == {}
+
+
+def test_point_value_sampler_tuple_to_string():
+    p = PointValueSamplerConfig(name="pp_well", variable="pp", point=(500, 250, 0))
+    assert p.pp_type == "PointValue"
+    assert p.point == "500 250 0"
+    assert p.variable == "pp"
+    # execute_on default for this subclass is None (overrides base default).
+    assert p.execute_on is None
+
+
+def test_point_value_sampler_string_point_passthrough():
+    p = PointValueSamplerConfig(name="pp", variable="pp", point="1 2 3")
+    assert p.point == "1 2 3"
+
+
+def test_line_value_sampler_serialization():
+    l = LineValueSamplerConfig(name="ln", variable="pp",
+                               start_point=(0, 1, 0), end_point=(2, 3, 0),
+                               num_points=51, output_vector=True)
+    assert l.pp_type == "LineValueSampler"
+    assert l.other_params["start_point"] == "0 1 0"
+    assert l.other_params["end_point"] == "2 3 0"
+    assert l.other_params["num_points"] == 51
+    assert l.other_params["output_vector_postprocessor"] is True
+    assert l.start_point_str == "0 1 0"
+    assert l.end_point_str == "2 3 0"
+    assert l.num_sample_points == 51
+
+
+def test_line_value_sampler_no_output_vector_key_omitted():
+    l = LineValueSamplerConfig(name="ln", variable="pp",
+                               start_point="0 0 0", end_point="1 1 1")
+    # When output_vector is False, the key is not added.
+    assert "output_vector_postprocessor" not in l.other_params
+    assert l.other_params["num_points"] == 100
+
+
+def test_generic_postprocessor_config_pops_standard_keys():
+    params = {"execute_on": "final", "variable": "pp", "foo": "bar"}
+    g = PostprocessorConfig(name="g", pp_type="ElementAverageValue", params=params)
+    assert g.pp_type == "ElementAverageValue"
+    assert g.execute_on == "final"
+    assert g.variable == "pp"
+    assert g.other_params == {"foo": "bar"}
+    # NOTE: the input dict is mutated in place (pop), 'foo' remains.
+    assert params == {"foo": "bar"}
+
+
+# --- SimpleFluidPropertiesConfig ------------------------------------------
+
+def test_simple_fluid_properties_defaults():
+    f = SimpleFluidPropertiesConfig(name="water")
+    assert f.name == "water"
+    assert f.bulk_modulus == 2.2E9
+    assert f.viscosity == 1.0E-3
+    assert f.density0 == 1000.0
+    assert f.thermal_expansion == 0.0002
+    assert f.cp == 4194.0
+    assert f.cv == 4186.0
+    assert f.porepressure_coefficient == 1.0
+
+
+# --- TimeStepperFunctionConfig --------------------------------------------
+
+def test_timestepper_function_config_maps_to_data1d():
+    tf = TimeStepperFunctionConfig(name="cs", x_values=[0, 1, 2],
+                                   y_values=[0.1, 0.2, 0.3])
+    assert tf.name == "cs"
+    np.testing.assert_array_equal(tf.taxis, np.array([0, 1, 2]))
+    np.testing.assert_array_equal(tf.data, np.array([0.1, 0.2, 0.3]))
+
+
+def test_timestepper_function_config_from_data1d():
+    d = Data1D(taxis=np.array([0., 10., 30.]), data=np.array([1., 2., 3.]))
+    tf = TimeStepperFunctionConfig.load_timestep_from_data1d("cs2", d)
+    # dt = diff(taxis)/2 = [5, 10], last appended -> [5, 10, 10]
+    np.testing.assert_array_equal(tf.data, np.array([5., 10., 10.]))
+    np.testing.assert_array_equal(tf.taxis, np.array([0., 10., 30.]))
+
+
+def test_timestepper_function_config_from_data1d_too_few_points_raises():
+    d = Data1D(taxis=np.array([0.]), data=np.array([1.]))
+    with pytest.raises(ValueError):
+        TimeStepperFunctionConfig.load_timestep_from_data1d("x", d)
+
+
+# --- AdaptiveTimeStepperConfig --------------------------------------------
+
+def test_adaptive_time_stepper_config():
+    tf = TimeStepperFunctionConfig(name="cs", x_values=[0, 1], y_values=[0.1, 0.1])
+    cfg = AdaptiveTimeStepperConfig(functions=[tf])
+    assert cfg.functions == [tf]
+
+
+# --- TimeSequenceStepper ---------------------------------------------------
+
+def test_time_sequence_stepper_from_list():
+    ts = TimeSequenceStepper([0, 1, 2.5])
+    assert ts.time_sequence == "0 1 2.5"
+
+
+def test_time_sequence_stepper_empty_default():
+    ts = TimeSequenceStepper()
+    assert ts.time_sequence == ""
+
+
+def test_time_sequence_stepper_bad_type_raises():
+    with pytest.raises(TypeError):
+        TimeSequenceStepper(time_sequence="not a list")
+
+
+def test_time_sequence_stepper_from_data1d():
+    ts = TimeSequenceStepper()
+    d = Data1D(taxis=np.array([0., 1., 2.]), data=np.array([1., 1., 1.]))
+    ts.from_data1d(d)
+    assert ts.time_sequence == "0.0 1.0 2.0"
+
+
+def test_time_sequence_stepper_from_data1d_empty_raises():
+    ts = TimeSequenceStepper()
+    d = Data1D(taxis=None, data=None)
+    with pytest.raises(ValueError):
+        ts.from_data1d(d)

--- a/tests/test_moose_editor.py
+++ b/tests/test_moose_editor.py
@@ -1,0 +1,95 @@
+# Characterization tests for fiberis.moose.editor.MooseModelEditor
+#
+# Golden-master tests for the public editor API exercised on a small model built
+# programmatically. Behavior pinned by RUNNING the code. Tests must stay GREEN
+# through a pure refactor.
+
+import pytest
+
+from fiberis.moose.model_builder import ModelBuilder
+from fiberis.moose.editor import MooseModelEditor
+
+
+def _small_builder():
+    """Build a tiny model with a couple of nested blocks for editing."""
+    b = ModelBuilder(project_name="EditorTest")
+    b.add_global_params({"displacements": "disp_x disp_y"})
+    b.add_variables(["pp", "disp_x"])
+    b.add_time_derivative_kernel(variable="pp", kernel_name="dot_pp")
+    b.add_boundary_condition(name="confinex", bc_type="DirichletBC",
+                             variable="disp_x", boundary_name="left",
+                             params={"value": 0})
+    return b
+
+
+def test_set_parameter_on_top_level_block():
+    b = _small_builder()
+    editor = MooseModelEditor(b)
+    editor.set_parameter(["GlobalParams"], "displacements", "disp_x disp_y disp_z")
+    assert editor.get_parameter(["GlobalParams"], "displacements") == "disp_x disp_y disp_z"
+
+
+def test_set_parameter_on_nested_block():
+    b = _small_builder()
+    editor = MooseModelEditor(b)
+    # Path: [BCs] -> [confinex], add/update 'value'.
+    editor.set_parameter(["BCs", "confinex"], "value", 42)
+    assert editor.get_parameter(["BCs", "confinex"], "value") == 42
+
+
+def test_set_parameter_adds_new_param():
+    b = _small_builder()
+    editor = MooseModelEditor(b)
+    editor.set_parameter(["Kernels", "dot_pp"], "extra", "thing")
+    assert editor.get_parameter(["Kernels", "dot_pp"], "extra") == "thing"
+
+
+def test_set_parameter_missing_path_raises():
+    b = _small_builder()
+    editor = MooseModelEditor(b)
+    with pytest.raises(ValueError):
+        editor.set_parameter(["DoesNotExist"], "x", 1)
+
+
+def test_get_parameter_missing_block_raises():
+    b = _small_builder()
+    editor = MooseModelEditor(b)
+    with pytest.raises(ValueError):
+        editor.get_parameter(["Nope", "Nada"], "x")
+
+
+def test_get_parameter_missing_param_raises_keyerror():
+    b = _small_builder()
+    editor = MooseModelEditor(b)
+    with pytest.raises(KeyError):
+        editor.get_parameter(["GlobalParams"], "no_such_param")
+
+
+def test_find_parameter_returns_all_paths():
+    b = _small_builder()
+    editor = MooseModelEditor(b)
+    # 'variable' is present on the kernel and the BC sub-blocks.
+    paths = editor.find_parameter("variable")
+    assert ["Kernels", "dot_pp"] in paths
+    assert ["BCs", "confinex"] in paths
+
+
+def test_find_parameter_not_found_returns_empty():
+    b = _small_builder()
+    editor = MooseModelEditor(b)
+    assert editor.find_parameter("totally_absent_param") == []
+
+
+def test_find_block_recursive_empty_path_returns_none():
+    b = _small_builder()
+    editor = MooseModelEditor(b)
+    assert editor._find_block_recursive([], b._top_level_blocks) is None
+
+
+def test_print_model_structure_smoke(capsys):
+    b = _small_builder()
+    editor = MooseModelEditor(b)
+    editor.print_model_structure()
+    out = capsys.readouterr().out
+    assert "MOOSE Model Structure for: EditorTest" in out
+    assert "[GlobalParams]" in out

--- a/tests/test_moose_input_generator.py
+++ b/tests/test_moose_input_generator.py
@@ -1,0 +1,207 @@
+# Characterization tests for fiberis.moose.input_generator
+#
+# These are golden-master / snapshot tests that pin the CURRENT behavior of the
+# low-level MooseBlock rendering and the generic generate_moose_input() function.
+# Golden output was obtained by RUNNING the code, not by hand-writing MOOSE syntax.
+# Tests must stay GREEN through a pure refactor.
+
+import os
+
+import pytest
+
+from fiberis.moose.input_generator import (
+    MooseBlock,
+    GeneratedMeshGeneratorBlock,
+    FunctionBlock,
+    generate_moose_input,
+)
+
+
+# --- MooseBlock.render() ---------------------------------------------------
+
+def test_empty_block_render():
+    block = MooseBlock("Mesh")
+    assert block.render() == "[Mesh]"
+
+
+def test_block_with_type_and_params_render():
+    block = MooseBlock("gen", block_type="GeneratedMeshGenerator")
+    block.add_param("dim", 2)
+    block.add_param("nx", 10)
+    rendered = block.render()
+    assert rendered == (
+        "[gen]\n"
+        "  type = GeneratedMeshGenerator\n"
+        "  dim = 2\n"
+        "  nx = 10"
+    )
+
+
+def test_format_value_bool_is_lowercased():
+    block = MooseBlock("b")
+    block.add_param("flag", True)
+    block.add_param("other", False)
+    rendered = block.render()
+    assert "flag = true" in rendered
+    assert "other = false" in rendered
+
+
+def test_format_value_numbers_not_quoted():
+    block = MooseBlock("b")
+    block.add_param("i", 5)
+    block.add_param("f", 3.5)
+    rendered = block.render()
+    assert "i = 5" in rendered
+    assert "f = 3.5" in rendered
+
+
+def test_format_value_list_and_tuple_space_joined():
+    block = MooseBlock("b")
+    block.add_param("lst", [1, 2, 3])
+    block.add_param("tup", (4, 5))
+    rendered = block.render()
+    assert "lst = 1 2 3" in rendered
+    assert "tup = 4 5" in rendered
+
+
+def test_format_value_plain_string_gets_single_quoted():
+    block = MooseBlock("b")
+    block.add_param("name", "hello")
+    assert "name = 'hello'" in block.render()
+
+
+def test_format_value_already_quoted_string_passed_through():
+    block = MooseBlock("b")
+    block.add_param("single", "'already'")
+    block.add_param("double", '"alsook"')
+    rendered = block.render()
+    # No double-quoting happens for pre-quoted strings.
+    assert "single = 'already'" in rendered
+    assert 'double = "alsook"' in rendered
+
+
+def test_indent_levels():
+    block = MooseBlock("Top")
+    block.add_param("a", 1)
+    rendered = block.render(indent_level=1)
+    # Top-level line indented by two spaces, params by four.
+    assert rendered.startswith("  [Top]")
+    assert "    a = 1" in rendered
+
+
+def test_nested_sub_block_render_with_closing_tags():
+    top = MooseBlock("Mesh")
+    sub = MooseBlock("gen", block_type="GeneratedMeshGenerator")
+    sub.add_param("dim", 2)
+    top.add_sub_block(sub)
+    rendered = top.render()
+    assert rendered == (
+        "[Mesh]\n"
+        "  [gen]\n"
+        "    type = GeneratedMeshGenerator\n"
+        "    dim = 2\n"
+        "  []"
+    )
+
+
+def test_type_param_not_duplicated_when_block_type_set():
+    # When a block_type is set, an explicit 'type' param is skipped during render.
+    block = MooseBlock("b", block_type="SomeType")
+    block.add_param("type", "ShouldBeIgnored")
+    rendered = block.render()
+    assert "type = SomeType" in rendered
+    assert "ShouldBeIgnored" not in rendered
+
+
+# --- GeneratedMeshGeneratorBlock ------------------------------------------
+
+def test_generated_mesh_generator_block():
+    block = GeneratedMeshGeneratorBlock("base", dim=2, nx=10, ny=20,
+                                        xmax=100.0, ymax=50.0, xmin=0)
+    rendered = block.render()
+    assert "type = GeneratedMeshGenerator" in rendered
+    assert "dim = 2" in rendered
+    assert "nx = 10" in rendered
+    assert "ny = 20" in rendered
+    assert "xmax = 100.0" in rendered
+    assert "ymax = 50.0" in rendered
+    assert "xmin = 0" in rendered
+
+
+# --- FunctionBlock ---------------------------------------------------------
+
+def test_function_block_expression_not_quoted():
+    # FunctionBlock 'expression' is rendered verbatim (no quoting by _format_value).
+    block = FunctionBlock("f", function_type="ParsedFunction", expression="2*x + 1")
+    rendered = block.render()
+    assert "type = ParsedFunction" in rendered
+    assert "expression = 2*x + 1" in rendered
+
+
+def test_function_block_extra_kwargs():
+    block = FunctionBlock("f", function_type="ParsedFunction",
+                          expression="t", vars="t")
+    rendered = block.render()
+    assert "expression = t" in rendered
+    assert "vars = 't'" in rendered
+
+
+# --- generate_moose_input() ------------------------------------------------
+
+def test_generate_moose_input_dict_params(tmp_path):
+    config = {"GlobalParams": {"displacements": "disp_x disp_y"}}
+    out = tmp_path / "out.i"
+    generate_moose_input(config, str(out))
+    assert out.exists()
+    text = out.read_text()
+    assert text.startswith("# MOOSE input file generated by input_generator.py")
+    assert "[GlobalParams]" in text
+    assert "displacements = 'disp_x disp_y'" in text
+    # Top-level block closing tag.
+    assert "[]" in text
+
+
+def test_generate_moose_input_list_subblocks(tmp_path):
+    config = {
+        "Variables": [
+            {"name": "pp", "params": {"initial_condition": 1.0}},
+            {"name": "disp_x"},
+        ]
+    }
+    out = tmp_path / "vars.i"
+    generate_moose_input(config, str(out))
+    text = out.read_text()
+    assert "[Variables]" in text
+    assert "[pp]" in text
+    assert "initial_condition = 1.0" in text
+    assert "[disp_x]" in text
+
+
+def test_generate_moose_input_parsedfunction_special_case(tmp_path):
+    config = {
+        "Functions": [
+            {"name": "myfunc", "type": "ParsedFunction",
+             "params": {"expression": "3*t"}},
+        ]
+    }
+    out = tmp_path / "f.i"
+    generate_moose_input(config, str(out))
+    text = out.read_text()
+    assert "[myfunc]" in text
+    assert "type = ParsedFunction" in text
+    # Expression rendered verbatim (FunctionBlock path).
+    assert "expression = 3*t" in text
+
+
+def test_generate_moose_input_missing_name_raises(tmp_path):
+    config = {"Variables": [{"params": {"x": 1}}]}
+    out = tmp_path / "bad.i"
+    with pytest.raises(ValueError):
+        generate_moose_input(config, str(out))
+
+
+def test_generate_moose_input_bad_type_raises(tmp_path):
+    config = {"Bad": "not a dict or list"}
+    out = tmp_path / "bad2.i"
+    with pytest.raises(TypeError):
+        generate_moose_input(config, str(out))

--- a/tests/test_moose_model_builder.py
+++ b/tests/test_moose_model_builder.py
@@ -1,0 +1,951 @@
+# Characterization tests for fiberis.moose.model_builder.ModelBuilder
+#
+# Golden-master / snapshot tests that build representative MOOSE models
+# programmatically, generate the resulting block structure / input text, and pin
+# the CURRENT output. All golden values were obtained by RUNNING the code, never
+# hand-written. These tests must stay GREEN through a pure refactor of the
+# input-generation layer (they do NOT run the MOOSE binary).
+
+import numpy as np
+import pytest
+
+from fiberis.moose.model_builder import ModelBuilder, OptimizationLayeredModelBuilder
+from fiberis.moose.config import (
+    ZoneMaterialProperties,
+    InitialConditionConfig,
+    MatrixConfig,
+    SRVConfig,
+    HydraulicFractureConfig,
+    CasingLayerConfig,
+    CasingConfig,
+    SimpleFluidPropertiesConfig,
+    PointValueSamplerConfig,
+    LineValueSamplerConfig,
+    PostprocessorConfig,
+    AdaptivityConfig,
+    IndicatorConfig,
+    MarkerConfig,
+    AdaptiveTimeStepperConfig,
+    TimeStepperFunctionConfig,
+    TimeSequenceStepper,
+)
+from fiberis.analyzer.Data1D import core1D
+
+
+# Helper to fetch a top-level block's rendered text by name.
+def _render_block(builder, name):
+    return builder._get_or_create_toplevel_moose_block(name).render()
+
+
+# --- Construction & basic structure ---------------------------------------
+
+def test_init_state():
+    b = ModelBuilder("MyProject")
+    assert b.project_name == "MyProject"
+    assert b._top_level_blocks == []
+    assert b.matrix_config is None
+    assert b.srv_configs == []
+    assert b.fracture_configs == []
+    assert b._next_available_block_id == 1
+
+
+def test_str_representation():
+    b = ModelBuilder("P")
+    b.add_variables(["pp"])
+    s = str(b)
+    assert "--- MOOSE Model Structure for: P ---" in s
+    assert "[Variables]" in s
+    assert "[pp]" in s
+    assert "-----------------------------" in s
+
+
+def test_get_or_create_toplevel_block_is_idempotent():
+    b = ModelBuilder("P")
+    blk1 = b._get_or_create_toplevel_moose_block("Mesh")
+    blk2 = b._get_or_create_toplevel_moose_block("Mesh")
+    assert blk1 is blk2
+    assert len(b._top_level_blocks) == 1
+
+
+def test_generate_unique_op_name():
+    assert ModelBuilder._generate_unique_op_name("foo", []) == "foo"
+    assert ModelBuilder._generate_unique_op_name("foo", ["foo"]) == "foo_1"
+    assert ModelBuilder._generate_unique_op_name("foo", ["foo", "foo_1"]) == "foo_2"
+
+
+# --- GlobalParams & Variables ---------------------------------------------
+
+def test_add_global_params():
+    b = ModelBuilder("P")
+    b.add_global_params({"displacements": "disp_x disp_y", "PorousFlowDictator": "dictator"})
+    rendered = _render_block(b, "GlobalParams")
+    assert "[GlobalParams]" in rendered
+    assert "displacements = 'disp_x disp_y'" in rendered
+    assert "PorousFlowDictator = 'dictator'" in rendered
+
+
+def test_add_variables_strings_and_dicts():
+    b = ModelBuilder("P")
+    b.add_variables([
+        {"name": "pp", "params": {"initial_condition": 26.4E6}},
+        "disp_x",
+        "disp_y",
+    ])
+    rendered = _render_block(b, "Variables")
+    assert "[pp]" in rendered
+    assert "initial_condition = 26400000.0" in rendered
+    assert "[disp_x]" in rendered
+    assert "[disp_y]" in rendered
+
+
+def test_add_variables_dict_without_name_raises():
+    b = ModelBuilder("P")
+    with pytest.raises(ValueError):
+        b.add_variables([{"params": {"x": 1}}])
+
+
+def test_add_variables_bad_type_raises():
+    b = ModelBuilder("P")
+    with pytest.raises(TypeError):
+        b.add_variables([123])
+
+
+# --- Mesh: stitched fractures ---------------------------------------------
+
+def test_build_stitched_mesh_single_fracture():
+    b = ModelBuilder("P")
+    b.build_stitched_mesh_for_fractures(
+        fracture_y_coords=250.0,
+        domain_bounds=(0, 500),
+        domain_length=1000.0,
+        nx=50,
+        ny_per_layer_half=15,
+        bias_y=1.2,
+    )
+    rendered = _render_block(b, "Mesh")
+    # Two half-panels stitched into one layer for a single interior seam.
+    assert "[layer0_panel_a]" in rendered
+    assert "[layer0_panel_b]" in rendered
+    assert "type = StitchedMeshGenerator" in rendered
+    assert "[stitched_layer_0]" in rendered
+    assert "inputs = 'layer0_panel_a layer0_panel_b'" in rendered
+    assert "stitch_boundaries_pairs = 'bottom top'" in rendered
+    # Panel A uses bias 1/1.2; panel B uses 1.2.
+    assert "bias_y = 0.8333333333333334" in rendered
+    assert "bias_y = 1.2" in rendered
+    # Geometry info recorded.
+    assert b.geometry_info["mesh"]["domain_bounds"] == (0, 500)
+    assert b.geometry_info["mesh"]["domain_length"] == 1000.0
+
+
+def test_build_stitched_mesh_multiple_fractures_final_stitch():
+    b = ModelBuilder("P")
+    b.build_stitched_mesh_for_fractures(
+        fracture_y_coords=[150.0, 350.0],
+        domain_bounds=(0, 500),
+        domain_length=1000.0,
+    )
+    rendered = _render_block(b, "Mesh")
+    # 3 layers between 4 y-points -> final stitching of layers.
+    assert "[stitched_layer_0]" in rendered
+    assert "[stitched_layer_2]" in rendered
+    assert "[final_stitch_0]" in rendered
+    assert "clear_stitched_boundary_ids = true" in rendered
+
+
+# --- Subdomains & block renaming ------------------------------------------
+
+def test_add_srv_and_fracture_subdomains_and_block_map():
+    b = ModelBuilder("P")
+    mats = ZoneMaterialProperties(porosity=0.1, permeability=1e-13)
+    srv = SRVConfig(name="SRV1", length=300, height=80, center_x=500,
+                    center_y=250, materials=mats)
+    frac = HydraulicFractureConfig(name="Frac1", length=200, height=0.2,
+                                   center_x=500, center_y=250, materials=mats)
+    b.add_srv_zone_2d(srv, target_block_id=1)
+    b.add_hydraulic_fracture_2d(frac, target_block_id=2)
+    rendered = _render_block(b, "Mesh")
+    assert "[SRV1_bbox]" in rendered
+    assert "type = SubdomainBoundingBoxGenerator" in rendered
+    assert "block_id = 1" in rendered
+    assert "[Frac1_bbox]" in rendered
+    assert "block_id = 2" in rendered
+    # SRV: center 500,250 length 300 height 80 -> bottom_left 350,210
+    assert "bottom_left = '350.0 210.0 0'" in rendered
+    assert "top_right = '650.0 290.0 0'" in rendered
+    assert b._block_id_to_name_map == {1: "SRV1", 2: "Frac1"}
+    assert b._next_available_block_id == 3
+
+
+def test_finalize_mesh_block_renaming_adds_matrix_zero():
+    b = ModelBuilder("P")
+    b.set_matrix_config(MatrixConfig(name="matrix",
+                        materials=ZoneMaterialProperties(porosity=0.05, permeability=1e-16)))
+    mats = ZoneMaterialProperties(porosity=0.1, permeability=1e-13)
+    b.add_srv_zone_2d(SRVConfig(name="SRV1", length=10, height=10, center_x=5,
+                                center_y=5, materials=mats), target_block_id=1)
+    b._finalize_mesh_block_renaming()
+    rendered = _render_block(b, "Mesh")
+    assert "type = RenameBlockGenerator" in rendered
+    assert "old_block = '0 1'" in rendered
+    assert "new_block = 'matrix SRV1'" in rendered
+
+
+def test_refine_blocks():
+    b = ModelBuilder("P")
+    b.refine_blocks(op_name="refine", block_ids=[1, 2], refinement_levels=[1, 2])
+    rendered = _render_block(b, "Mesh")
+    assert "type = RefineBlockGenerator" in rendered
+    assert "block = '1 2'" in rendered
+    assert "refinement = '1 2'" in rendered
+
+
+def test_refine_blocks_scalar_level_broadcast():
+    b = ModelBuilder("P")
+    b.refine_blocks(op_name="refine", block_ids=[1, 2, 3], refinement_levels=2)
+    rendered = _render_block(b, "Mesh")
+    assert "refinement = '2 2 2'" in rendered
+
+
+def test_refine_blocks_mismatched_lengths_raises():
+    b = ModelBuilder("P")
+    with pytest.raises(ValueError):
+        b.refine_blocks(op_name="r", block_ids=[1, 2], refinement_levels=[1])
+
+
+# --- Boundaries & nodesets -------------------------------------------------
+
+def test_add_named_boundary():
+    b = ModelBuilder("P")
+    b.add_named_boundary("left", (0, 0, 0), (0, 500, 0))
+    rendered = _render_block(b, "Mesh")
+    assert "[sideset_left]" in rendered
+    assert "type = SideSetsAroundBoundingBoxGenerator" in rendered
+    assert "boundary_names = 'left'" in rendered
+    assert "bottom_left = '0 0 0'" in rendered
+    assert {"name": "left", "start": (0, 0, 0), "end": (0, 500, 0)} in b.geometry_info["boundaries"]
+
+
+def test_add_nodeset_by_coord():
+    b = ModelBuilder("P")
+    b.add_nodeset_by_coord("well_nodes", "injection_well", (500, 250, 0))
+    rendered = _render_block(b, "Mesh")
+    assert "[well_nodes]" in rendered
+    assert "type = ExtraNodesetGenerator" in rendered
+    assert "new_boundary = 'injection_well'" in rendered
+    assert "coord = '500 250 0'" in rendered
+
+
+def test_add_nodeset_by_bbox():
+    b = ModelBuilder("P")
+    b.add_nodeset_by_bbox("ns", "bnd", (0, 0, 0), (1, 1, 0))
+    rendered = _render_block(b, "Mesh")
+    assert "type = BoundingBoxNodeSetGenerator" in rendered
+    assert "new_boundary = 'bnd'" in rendered
+    assert "bottom_left = '0 0 0'" in rendered
+
+
+def test_add_linear_pressure_boundary_creates_nodeset_and_bc():
+    b = ModelBuilder("P")
+    b.add_linear_pressure_boundary(
+        boundary_name="inj", bottom_left=(0, 0, 0), top_right=(1, 1, 0),
+        pressure_function_name="pfunc")
+    mesh = _render_block(b, "Mesh")
+    bcs = _render_block(b, "BCs")
+    assert "[inj_generator]" in mesh
+    assert "[inj_pressure_bc]" in bcs
+    assert "type = FunctionDirichletBC" in bcs
+    assert "function = 'pfunc'" in bcs
+
+
+# --- Kernels ---------------------------------------------------------------
+
+def test_add_time_derivative_kernel_default_name():
+    b = ModelBuilder("P")
+    b.add_time_derivative_kernel(variable="pp")
+    rendered = _render_block(b, "Kernels")
+    assert "[dot_pp]" in rendered
+    assert "type = TimeDerivative" in rendered
+    assert "variable = 'pp'" in rendered
+
+
+def test_add_function_diffusion_kernel_block_list_joined():
+    b = ModelBuilder("P")
+    b.add_function_diffusion_kernel("diff", "pp", "kfunc", ["matrix", "SRV1"])
+    rendered = _render_block(b, "Kernels")
+    assert "type = FunctionDiffusion" in rendered
+    assert "function = 'kfunc'" in rendered
+    assert "block = 'matrix SRV1'" in rendered
+
+
+def test_add_anisotropic_diffusion_kernel():
+    b = ModelBuilder("P")
+    b.add_anisotropic_diffusion_kernel("aniso", "pp", "matrix", "1 0 0 0 1 0 0 0 1")
+    rendered = _render_block(b, "Kernels")
+    assert "type = AnisotropicDiffusion" in rendered
+    assert "tensor_coeff = '1 0 0 0 1 0 0 0 1'" in rendered
+
+
+def test_add_porous_flow_darcy_base_kernel():
+    b = ModelBuilder("P")
+    b.add_porous_flow_darcy_base_kernel("flux", "pp")
+    rendered = _render_block(b, "Kernels")
+    assert "type = PorousFlowFullySaturatedDarcyBase" in rendered
+    assert "gravity = '0 0 0'" in rendered
+
+
+def test_add_stress_divergence_tensor_kernel():
+    b = ModelBuilder("P")
+    b.add_stress_divergence_tensor_kernel("grad_x", "disp_x", 0)
+    rendered = _render_block(b, "Kernels")
+    assert "type = StressDivergenceTensors" in rendered
+    assert "component = 0" in rendered
+
+
+def test_add_effective_stress_coupling_kernel():
+    b = ModelBuilder("P")
+    b.add_porous_flow_effective_stress_coupling_kernel("eff_x", "disp_x", 0, 0.7)
+    rendered = _render_block(b, "Kernels")
+    assert "type = PorousFlowEffectiveStressCoupling" in rendered
+    assert "biot_coefficient = 0.7" in rendered
+
+
+def test_add_mass_volumetric_expansion_and_time_derivative_kernels():
+    b = ModelBuilder("P")
+    b.add_porous_flow_mass_volumetric_expansion_kernel("mass_exp", "pp")
+    b.add_porous_flow_mass_time_derivative_kernel("mass_dt", "pp")
+    rendered = _render_block(b, "Kernels")
+    assert "type = PorousFlowMassVolumetricExpansion" in rendered
+    assert "type = PorousFlowMassTimeDerivative" in rendered
+    assert "fluid_component = 0" in rendered
+
+
+def test_add_custom_kernel():
+    b = ModelBuilder("P")
+    b.add_custom_kernel(kernel_type="MyKernel", kernel_name="kk", variable="pp",
+                        params={"foo": "bar"}, extra=5)
+    rendered = _render_block(b, "Kernels")
+    assert "[kk]" in rendered
+    assert "type = MyKernel" in rendered
+    assert "foo = 'bar'" in rendered
+    assert "extra = 5" in rendered
+
+
+# --- UserObjects / dictator ------------------------------------------------
+
+def test_add_user_object_replaces_same_name():
+    b = ModelBuilder("P")
+    b.add_user_object("uo", "TypeA", {"x": 1})
+    b.add_user_object("uo", "TypeB", {"y": 2})
+    rendered = _render_block(b, "UserObjects")
+    assert "type = TypeB" in rendered
+    assert "type = TypeA" not in rendered
+    # Only one sub-block remains.
+    assert b._get_or_create_toplevel_moose_block("UserObjects").sub_blocks.__len__() == 1
+
+
+def test_set_porous_flow_dictator():
+    b = ModelBuilder("P")
+    b.set_porous_flow_dictator(porous_flow_variables=["pp", "disp_x"],
+                               num_fluid_phases=1, num_fluid_components=1)
+    rendered = _render_block(b, "UserObjects")
+    assert "type = PorousFlowDictator" in rendered
+    assert "porous_flow_vars = 'pp disp_x'" in rendered
+    assert "number_fluid_phases = 1" in rendered
+
+
+# --- Boundary conditions ---------------------------------------------------
+
+def test_add_boundary_condition_with_list_boundary():
+    b = ModelBuilder("P")
+    b.add_boundary_condition("confinex", "DirichletBC", "disp_x",
+                             ["left", "right"], params={"value": 0})
+    rendered = _render_block(b, "BCs")
+    assert "type = DirichletBC" in rendered
+    assert "boundary = 'left right'" in rendered
+    assert "value = 0" in rendered
+
+
+def test_set_hydraulic_fracturing_bcs_clears_and_sets():
+    b = ModelBuilder("P")
+    b.add_boundary_condition("stale", "DirichletBC", "x", "b")
+    b.set_hydraulic_fracturing_bcs(
+        injection_well_boundary_name="injection_well",
+        injection_pressure_function_name="pfunc",
+        confine_disp_x_boundaries="left right",
+        confine_disp_y_boundaries="top bottom")
+    rendered = _render_block(b, "BCs")
+    # Old BC cleared.
+    assert "[stale]" not in rendered
+    assert "[injection_pressure]" in rendered
+    assert "function = 'pfunc'" in rendered
+    assert "[confinex]" in rendered
+    assert "[confiney]" in rendered
+
+
+# --- Functions -------------------------------------------------------------
+
+def test_add_piecewise_function_from_data1d():
+    b = ModelBuilder("P")
+    d = core1D.Data1D(taxis=np.array([0, 1800, 3600]),
+                      data=np.array([27e6, 45e6, 40e6]))
+    b.add_piecewise_function_from_data1d("inj_func", d)
+    rendered = _render_block(b, "Functions")
+    assert "[inj_func]" in rendered
+    assert "type = PiecewiseLinear" in rendered
+    assert "x = '0 1800 3600'" in rendered
+    assert "y = '27000000.0 45000000.0 40000000.0'" in rendered
+
+
+def test_add_piecewise_function_wrong_type_raises():
+    b = ModelBuilder("P")
+    with pytest.raises(TypeError):
+        b.add_piecewise_function_from_data1d("f", "not a data1d")
+
+
+def test_add_piecewise_function_empty_data1d_raises():
+    b = ModelBuilder("P")
+    d = core1D.Data1D()
+    with pytest.raises(ValueError):
+        b.add_piecewise_function_from_data1d("f", d)
+
+
+# --- Fluid properties & Materials -----------------------------------------
+
+def test_add_simple_fluid_properties():
+    b = ModelBuilder("P")
+    b.add_simple_fluid_properties(SimpleFluidPropertiesConfig(name="water"))
+    rendered = _render_block(b, "FluidProperties")
+    assert "[water]" in rendered
+    assert "type = SimpleFluidProperties" in rendered
+    assert "bulk_modulus = 2200000000.0" in rendered
+    assert "viscosity = 0.001" in rendered
+    assert "density0 = 1000.0" in rendered
+
+
+def test_add_simple_fluid_properties_wrong_type_raises():
+    b = ModelBuilder("P")
+    with pytest.raises(TypeError):
+        b.add_simple_fluid_properties("not a config")
+
+
+def test_add_poromechanics_materials_fracture_workflow():
+    b = ModelBuilder("P")
+    matrix_mats = ZoneMaterialProperties(porosity=0.05, permeability="'1e-15 0 0 0 1e-15 0 0 0 1e-16'",
+                                         youngs_modulus=3e10, poissons_ratio=0.25)
+    srv_mats = ZoneMaterialProperties(porosity=0.1, permeability="'1e-13 0 0'")
+    b.set_matrix_config(MatrixConfig(name="matrix", materials=matrix_mats))
+    b.add_srv_config(SRVConfig(name="SRV1", length=10, height=10, center_x=5,
+                               center_y=5, materials=srv_mats))
+    b.add_fluid_properties_config(SimpleFluidPropertiesConfig(name="water"))
+    b.add_poromechanics_materials(fluid_properties_name="water",
+                                  biot_coefficient=0.7, solid_bulk_compliance=1e-11)
+    rendered = _render_block(b, "Materials")
+    assert "[porosity_matrix]" in rendered
+    assert "type = PorousFlowPorosityConst" in rendered
+    assert "[permeability_matrix]" in rendered
+    assert "[elasticity_tensor_matrix]" in rendered
+    assert "youngs_modulus = 30000000000.0" in rendered
+    assert "poissons_ratio = 0.25" in rendered
+    assert "[biot_modulus]" in rendered
+    assert "type = PorousFlowConstantBiotModulus" in rendered
+    assert "fluid_bulk_modulus = 2200000000.0" in rendered
+    assert "block = 'matrix SRV1'" in rendered
+    assert "type = ComputeLinearElasticStress" in rendered
+    assert "type = PorousFlowVolumetricStrain" in rendered
+
+
+def test_add_poromechanics_materials_missing_fluid_raises():
+    b = ModelBuilder("P")
+    b.set_matrix_config(MatrixConfig(name="matrix",
+                        materials=ZoneMaterialProperties(porosity=0.05, permeability=1e-16)))
+    with pytest.raises(ValueError):
+        b.add_poromechanics_materials(fluid_properties_name="nope",
+                                      biot_coefficient=0.7, solid_bulk_compliance=1e-11)
+
+
+def test_add_poromechanics_materials_npz_permeability_path(tmp_path):
+    # A permeability given as a path to an .npz triggers a time-dependent
+    # FunctionAux + PorousFlowPermeabilityTensorFromVar workflow.
+    npz = tmp_path / "perm.npz"
+    np.savez(npz, taxis=np.array([0., 1., 2.]),
+             data=np.array([1e-13, 2e-13, 3e-13]),
+             start_time="2020-01-01T00:00:00")
+    mats = ZoneMaterialProperties(porosity=0.1, permeability=str(npz))
+    b = ModelBuilder("P")
+    b.set_matrix_config(MatrixConfig(name="matrix", materials=mats))
+    b.add_fluid_properties_config(SimpleFluidPropertiesConfig(name="water"))
+    b.add_poromechanics_materials(fluid_properties_name="water",
+                                  biot_coefficient=0.7, solid_bulk_compliance=1e-11)
+    materials = _render_block(b, "Materials")
+    aux_vars = _render_block(b, "AuxVariables")
+    aux_kernels = _render_block(b, "AuxKernels")
+    functions = _render_block(b, "Functions")
+    assert "type = PorousFlowPermeabilityTensorFromVar" in materials
+    assert "perm = 'scalar_perm_matrix'" in materials
+    assert "[scalar_perm_matrix]" in aux_vars
+    assert "type = FunctionAux" in aux_kernels
+    assert "[perm_func_matrix]" in functions
+
+
+def test_set_main_domain_parameters_2d_deprecated(capsys):
+    b = ModelBuilder("P")
+    result = b.set_main_domain_parameters_2d(foo=1)
+    assert result is b
+    assert "deprecated" in capsys.readouterr().out
+
+
+def test_set_adaptivity_options_fallback_no_config():
+    b = ModelBuilder("P")
+    b.set_adaptivity_options(enable=True)
+    rendered = _render_block(b, "Adaptivity")
+    assert "marker = 'default_marker'" in rendered
+    assert "[default_indicator]" in rendered
+    assert "refine = 0.5" in rendered
+
+
+def test_set_adaptivity_options_disable_when_absent_is_noop():
+    b = ModelBuilder("P")
+    result = b.set_adaptivity_options(enable=False)
+    assert result is b
+    assert b._top_level_blocks == []
+
+
+# --- AuxVariables / AuxKernels --------------------------------------------
+
+def test_add_standard_tensor_aux_vars_and_kernels():
+    b = ModelBuilder("P")
+    b.add_standard_tensor_aux_vars_and_kernels({"stress": "stress"})
+    aux_vars = _render_block(b, "AuxVariables")
+    aux_kernels = _render_block(b, "AuxKernels")
+    assert "[stress_xx]" in aux_vars
+    assert "[stress_yy]" in aux_vars
+    assert "order = 'CONSTANT'" in aux_vars
+    assert "family = 'MONOMIAL'" in aux_vars
+    assert "type = RankTwoAux" in aux_kernels
+    assert "rank_two_tensor = 'stress'" in aux_kernels
+    assert "index_i = 0" in aux_kernels
+
+
+def test_add_standard_tensor_aux_rate_variant():
+    b = ModelBuilder("P")
+    b.add_standard_tensor_aux_vars_and_kernels({"strain": "strain", "strain_rate": "strain_rate"})
+    aux_kernels = _render_block(b, "AuxKernels")
+    assert "type = TimeDerivativeAux" in aux_kernels
+    assert "[strain_rate_xx]" in aux_kernels
+    assert "functor = 'strain_xx'" in aux_kernels
+
+
+def test_add_standard_tensor_aux_rate_missing_base_raises():
+    b = ModelBuilder("P")
+    with pytest.raises(ValueError):
+        b.add_standard_tensor_aux_vars_and_kernels({"strain_rate": "strain_rate"})
+
+
+# --- Initial conditions ----------------------------------------------------
+
+def test_add_initial_conditions_from_configs():
+    b = ModelBuilder("P")
+    ic = InitialConditionConfig(name="ppic", ic_type="ConstantIC",
+                                variable="pp", params={"value": 1.0})
+    b.set_matrix_config(MatrixConfig(name="matrix",
+                        materials=ZoneMaterialProperties(porosity=0.05, permeability=1e-16),
+                        initial_conditions=[ic]))
+    b.add_initial_conditions_from_configs()
+    rendered = _render_block(b, "ICs")
+    assert "[ppic_matrix]" in rendered
+    assert "type = ConstantIC" in rendered
+    assert "variable = 'pp'" in rendered
+    assert "block = 'matrix'" in rendered
+    assert "value = 1.0" in rendered
+
+
+# --- Adaptivity ------------------------------------------------------------
+
+def test_set_adaptivity_options_with_config():
+    b = ModelBuilder("P")
+    cfg = AdaptivityConfig(
+        marker_to_use="mymarker", steps=3,
+        indicators=[IndicatorConfig("ind", "GradientJumpIndicator", {"variable": "pp"})],
+        markers=[MarkerConfig("mymarker", "ErrorFractionMarker",
+                              {"indicator": "ind", "refine": 0.3})])
+    b.set_adaptivity_options(enable=True, config=cfg)
+    rendered = _render_block(b, "Adaptivity")
+    assert "marker = 'mymarker'" in rendered
+    assert "steps = 3" in rendered
+    assert "[Indicators]" in rendered
+    assert "type = GradientJumpIndicator" in rendered
+    assert "[Markers]" in rendered
+    assert "type = ErrorFractionMarker" in rendered
+
+
+def test_set_adaptivity_options_default_template():
+    b = ModelBuilder("P")
+    b.set_adaptivity_options(enable=True,
+                             default_template_settings={"monitored_variable": "pp"})
+    rendered = _render_block(b, "Adaptivity")
+    assert "marker = 'marker_for_pp'" in rendered
+    assert "[indicator_on_pp]" in rendered
+    assert "refine = 0.3" in rendered
+    assert "coarsen = 0.05" in rendered
+
+
+def test_set_adaptivity_options_disable_removes_block():
+    b = ModelBuilder("P")
+    b.set_adaptivity_options(enable=True, default_template_settings={})
+    b.set_adaptivity_options(enable=False)
+    assert all(blk.block_name != "Adaptivity" for blk in b._top_level_blocks)
+
+
+def test_set_adaptivity_options_wrong_config_type_raises():
+    b = ModelBuilder("P")
+    with pytest.raises(TypeError):
+        b.set_adaptivity_options(enable=True, config="not a config")
+
+
+# --- Postprocessors --------------------------------------------------------
+
+def test_add_point_value_postprocessor():
+    b = ModelBuilder("P")
+    b.add_postprocessor(PointValueSamplerConfig(name="pp_well", variable="pp",
+                                                point=(500, 250, 0)))
+    rendered = _render_block(b, "Postprocessors")
+    assert "[pp_well]" in rendered
+    assert "type = PointValue" in rendered
+    assert "variable = 'pp'" in rendered
+    assert "point = '500 250 0'" in rendered
+
+
+def test_add_line_value_postprocessor_goes_to_vector_block():
+    b = ModelBuilder("P")
+    b.add_postprocessor(LineValueSamplerConfig(
+        name="profile", variable="pp stress_yy",
+        start_point=(0, 250, 0), end_point=(1000, 250, 0),
+        num_points=101, output_vector=True))
+    rendered = _render_block(b, "VectorPostprocessors")
+    assert "[profile]" in rendered
+    assert "type = LineValueSampler" in rendered
+    assert "start_point = '0 250 0'" in rendered
+    assert "num_points = 101" in rendered
+
+
+def test_add_generic_postprocessor():
+    b = ModelBuilder("P")
+    b.add_postprocessor(PostprocessorConfig(name="avg", pp_type="ElementAverageValue",
+                                            params={"variable": "pp"}))
+    rendered = _render_block(b, "Postprocessors")
+    assert "[avg]" in rendered
+    assert "type = ElementAverageValue" in rendered
+
+
+def test_add_postprocessor_wrong_type_raises():
+    b = ModelBuilder("P")
+    with pytest.raises(TypeError):
+        b.add_postprocessor("not a config")
+
+
+# --- Executioner / Preconditioning / Outputs ------------------------------
+
+def test_add_executioner_block_constant_dt():
+    b = ModelBuilder("P")
+    b.add_executioner_block(end_time=3600, time_stepper_type="ConstantDT", dt=100)
+    rendered = _render_block(b, "Executioner")
+    assert "type = 'Transient'" in rendered
+    assert "solve_type = 'Newton'" in rendered
+    assert "end_time = 3600" in rendered
+    assert "[TimeStepper]" in rendered
+    assert "type = ConstantDT" in rendered
+    assert "dt = 100" in rendered
+
+
+def test_add_executioner_block_constant_dt_missing_dt_raises():
+    b = ModelBuilder("P")
+    with pytest.raises(ValueError):
+        b.add_executioner_block(end_time=10, time_stepper_type="ConstantDT")
+
+
+def test_add_executioner_block_time_sequence_stepper():
+    b = ModelBuilder("P")
+    b.add_executioner_block(end_time=4, time_stepper_type="TimeSequenceStepper",
+                            stepper_config=TimeSequenceStepper([0, 1, 2, 4]))
+    rendered = _render_block(b, "Executioner")
+    assert "type = TimeSequenceStepper" in rendered
+    assert "time_sequence = '0 1 2 4'" in rendered
+
+
+def test_add_executioner_block_iteration_adaptive_dt():
+    b = ModelBuilder("P")
+    func = TimeStepperFunctionConfig(name="sched", x_values=[0, 100], y_values=[10, 10])
+    cfg = AdaptiveTimeStepperConfig(functions=[func])
+    b.add_executioner_block(end_time=100, time_stepper_type="IterationAdaptiveDT",
+                            dt=10, stepper_config=cfg)
+    exec_rendered = _render_block(b, "Executioner")
+    func_rendered = _render_block(b, "Functions")
+    assert "type = IterationAdaptiveDT" in exec_rendered
+    assert "force_step_every_function_point = true" in exec_rendered
+    assert "timestep_limiting_function = 'sched'" in exec_rendered
+    # The schedule function is added to [Functions].
+    assert "[sched]" in func_rendered
+
+
+def test_add_executioner_block_adaptive_wrong_config_raises():
+    b = ModelBuilder("P")
+    with pytest.raises(TypeError):
+        b.add_executioner_block(end_time=10, time_stepper_type="IterationAdaptiveDT",
+                                dt=1, stepper_config="bad")
+
+
+def test_add_preconditioning_block():
+    b = ModelBuilder("P")
+    b.add_preconditioning_block(active_preconditioner="mumps")
+    rendered = _render_block(b, "Preconditioning")
+    assert "active = 'mumps'" in rendered
+    assert "[mumps]" in rendered
+    assert "type = SMP" in rendered
+    assert "[basic]" in rendered
+
+
+def test_add_outputs_block_default():
+    b = ModelBuilder("P")
+    b.add_outputs_block(exodus=True, csv=True)
+    rendered = _render_block(b, "Outputs")
+    assert "[exodus]" in rendered
+    assert "type = Exodus" in rendered
+    assert "[csv]" in rendered
+    assert "type = CSV" in rendered
+
+
+def test_add_outputs_block_exodus_execute_on_and_replace():
+    b = ModelBuilder("P")
+    b.add_outputs_block(exodus=True, csv=False)
+    b.add_outputs_block(exodus=True, csv=True, exodus_execute_on="FINAL")
+    rendered = _render_block(b, "Outputs")
+    assert "execute_on = 'FINAL'" in rendered
+    assert "[csv]" in rendered
+    # Only a single exodus block exists after replacement.
+    outputs = b._get_or_create_toplevel_moose_block("Outputs")
+    exodus_blocks = [sb for sb in outputs.sub_blocks if sb.block_name == "exodus"]
+    assert len(exodus_blocks) == 1
+
+
+# --- Casing model ----------------------------------------------------------
+
+def _casing_builder():
+    b = ModelBuilder("Cas")
+    mats1 = ZoneMaterialProperties(porosity=0.1, permeability=1e-15,
+                                   youngs_modulus=3e10, poissons_ratio=0.25)
+    mats2 = ZoneMaterialProperties(porosity=0.2, permeability=1e-13,
+                                   youngs_modulus=2e10, poissons_ratio=0.2)
+    layers = [CasingLayerConfig("top", 10.0, mats1),
+              CasingLayerConfig("bot", 20.0, mats2)]
+    cc = CasingConfig("casing", layers, injection_well_name="well",
+                      injection_well_x_coord=50.0)
+    b.add_casing_config(cc)
+    return b
+
+
+def test_build_mesh_for_casing_model():
+    b = _casing_builder()
+    b.build_mesh_for_casing_model(domain_length=100.0, nx=10, ny=10)
+    rendered = _render_block(b, "Mesh")
+    assert "[base_mesh]" in rendered
+    # Total height 30 -> ymin/ymax -15/15.
+    assert "ymin = -15.0" in rendered
+    assert "ymax = 15.0" in rendered
+    assert "[top_bbox]" in rendered
+    assert "[bot_bbox]" in rendered
+    assert "[injection_well_nodes]" in rendered
+    assert "new_boundary = 'well'" in rendered
+    assert "[final_block_rename]" in rendered
+    assert "new_block = 'top bot'" in rendered
+    assert b._block_id_to_name_map == {1: "top", 2: "bot"}
+    assert b.geometry_info["mesh"]["type"] == "casing_model_srv_layers"
+
+
+def test_build_mesh_for_casing_model_without_config_raises():
+    b = ModelBuilder("P")
+    with pytest.raises(ValueError):
+        b.build_mesh_for_casing_model(domain_length=100.0, nx=10, ny=10)
+
+
+def test_add_poromechanics_materials_casing_workflow():
+    b = _casing_builder()
+    b.build_mesh_for_casing_model(domain_length=100.0, nx=10, ny=10)
+    b.add_fluid_properties_config(SimpleFluidPropertiesConfig(name="water"))
+    b.add_poromechanics_materials(fluid_properties_name="water",
+                                  biot_coefficient=0.7, solid_bulk_compliance=1e-11)
+    rendered = _render_block(b, "Materials")
+    # Per-layer materials.
+    assert "[porosity_top]" in rendered
+    assert "[permeability_top]" in rendered
+    assert "[elasticity_tensor_top]" in rendered
+    assert "[porosity_bot]" in rendered
+    assert "block = 'top bot'" in rendered
+
+
+# --- save/load round trip & full input generation -------------------------
+
+def test_save_and_load_npz_roundtrip(tmp_path):
+    b = ModelBuilder("RoundTrip")
+    b.add_variables(["pp"])
+    b.add_time_derivative_kernel(variable="pp")
+    fp = tmp_path / "state.npz"
+    b.save_npz(str(fp))
+    assert fp.exists()
+    loaded = ModelBuilder.load_npz(str(fp))
+    assert isinstance(loaded, ModelBuilder)
+    assert loaded.project_name == "RoundTrip"
+    assert str(loaded) == str(b)
+
+
+def test_save_npz_appends_extension(tmp_path):
+    b = ModelBuilder("P")
+    b.add_variables(["pp"])
+    target = tmp_path / "noext"
+    b.save_npz(str(target))
+    assert (tmp_path / "noext.npz").exists()
+
+
+def test_generate_input_file_empty_raises(tmp_path):
+    b = ModelBuilder("Empty")
+    with pytest.raises(ValueError):
+        b.generate_input_file(str(tmp_path / "empty.i"))
+
+
+def test_generate_input_file_full(tmp_path):
+    b = ModelBuilder("Full")
+    b.add_variables(["pp", "disp_x"])
+    b.add_time_derivative_kernel(variable="pp")
+    b.add_executioner_block(end_time=10, time_stepper_type="ConstantDT", dt=1)
+    out = tmp_path / "full.i"
+    b.generate_input_file(str(out))
+    text = out.read_text()
+    assert text.startswith("# MOOSE input file generated by ModelBuilder for project: Full")
+    assert "[Variables]" in text
+    assert "[Kernels]" in text
+    assert "[Executioner]" in text
+    # Each top-level block is closed with [].
+    assert "[]" in text
+
+
+def test_build_example_with_all_features(tmp_path):
+    # End-to-end golden master of the documented example workflow.
+    out = tmp_path / "example.i"
+    ModelBuilder.build_example_with_all_features(str(out))
+    assert out.exists()
+    text = out.read_text()
+    assert "project: StitchedMeshFracExample" in text
+    assert "[Mesh]" in text
+    assert "type = StitchedMeshGenerator" in text
+    assert "[Variables]" in text
+    assert "[Kernels]" in text
+    assert "[Materials]" in text
+    assert "[BCs]" in text
+    assert "[Functions]" in text
+    assert "[Postprocessors]" in text
+    assert "[VectorPostprocessors]" in text
+    assert "[Executioner]" in text
+    assert "[Preconditioning]" in text
+    assert "[Outputs]" in text
+    assert "type = RenameBlockGenerator" in text
+
+
+def test_extract_geometry():
+    b = ModelBuilder("P")
+    mats = ZoneMaterialProperties(porosity=0.1, permeability=1e-13)
+    b.build_stitched_mesh_for_fractures(250.0, (0, 500), 1000.0)
+    b.add_srv_zone_2d(SRVConfig(name="SRV1", length=10, height=10, center_x=5,
+                                center_y=5, materials=mats), target_block_id=1)
+    geo = b.extract_geometry()
+    assert "mesh" in geo
+    assert geo["mesh"]["domain_length"] == 1000.0
+    assert len(geo["srv_zones"]) == 1
+
+
+# --- OptimizationLayeredModelBuilder --------------------------------------
+
+def _opt_builder():
+    b = OptimizationLayeredModelBuilder("Opt")
+    mats = ZoneMaterialProperties(porosity=0.1, permeability=1e-15,
+                                  youngs_modulus=3e10, poissons_ratio=0.25)
+    layers = [CasingLayerConfig("l1", 10.0, mats),
+              CasingLayerConfig("l2", 10.0, mats)]
+    cc = CasingConfig("casing", layers, injection_well_name="well",
+                      injection_well_x_coord=50.0)
+    b.set_casing_config(cc)
+    return b
+
+
+def test_optimization_builder_set_casing_config():
+    b = _opt_builder()
+    assert b.casing_config is not None
+    assert len(b.casing_config.layers) == 2
+
+
+def test_optimization_builder_adjoint_variables():
+    b = _opt_builder()
+    b.add_adjoint_variables()
+    rendered = _render_block(b, "Variables")
+    assert "[pp_adjoint]" in rendered
+    assert "solver_sys = 'adjoint'" in rendered
+    assert "[disp_x_adjoint]" in rendered
+
+
+def test_optimization_setup_forward_model():
+    b = _opt_builder()
+    b.setup_optimization_forward_model(perm_y=1e-20, perm_z=0.0)
+    funcs = _render_block(b, "Functions")
+    aux_kernels = _render_block(b, "AuxKernels")
+    vpps = _render_block(b, "VectorPostprocessors")
+    assert "[func_kyy]" in funcs
+    assert "type = ParsedFunction" in funcs
+    assert "[perm_l1]" in funcs
+    assert "type = ParsedOptimizationFunction" in funcs
+    assert "type = FunctionAux" in aux_kernels
+    assert "type = ElementOptimizationAnisotropicDiffusionInnerProduct" in vpps
+
+
+def test_optimization_setup_forward_model_without_config_raises():
+    b = OptimizationLayeredModelBuilder("Opt")
+    with pytest.raises(ValueError):
+        b.setup_optimization_forward_model()
+
+
+def test_optimization_executioner_block():
+    b = _opt_builder()
+    b.add_optimization_executioner_block(end_time=10, time_stepper_type="ConstantDT", dt=1)
+    rendered = _render_block(b, "Executioner")
+    assert "type = 'TransientAndAdjoint'" in rendered
+    assert "forward_system = 'nl0'" in rendered
+    assert "adjoint_system = 'adjoint'" in rendered
+
+
+def test_optimization_preconditioning_block():
+    b = _opt_builder()
+    b.add_preconditioning_block()
+    rendered = _render_block(b, "Preconditioning")
+    assert "[nl0]" in rendered
+    assert "nl_sys = 'nl0'" in rendered
+    assert "[adjoint]" in rendered
+    assert "nl_sys = 'adjoint'" in rendered
+
+
+def test_optimization_problem_block():
+    b = _opt_builder()
+    b.add_optimization_problem_block()
+    rendered = _render_block(b, "Problem")
+    assert "nl_sys_names = 'nl0 adjoint'" in rendered
+    assert "kernel_coverage_check = false" in rendered
+
+
+def test_optimization_reporters_and_dirac():
+    b = _opt_builder()
+    b.add_optimization_reporters_and_dirac(measurement_variable="disp_y")
+    reporters = _render_block(b, "Reporters")
+    dirac = _render_block(b, "DiracKernels")
+    assert "[data]" in reporters
+    assert "type = OptimizationData" in reporters
+    assert "[params]" in reporters
+    assert "real_vector_names = 'perm_1 perm_2'" in reporters
+    assert "[misfit]" in dirac
+    assert "variable = 'disp_y_adjoint'" in dirac

--- a/tests/test_moose_postprocessor.py
+++ b/tests/test_moose_postprocessor.py
@@ -1,0 +1,241 @@
+# Characterization tests for fiberis.moose.postprocessor.
+#
+# The MooseOutputReader class depends on meshio reading real Exodus II files
+# (which we do not have), so it is exercised via a lightweight in-memory mesh
+# (mirroring the module's own __main__ MockMooseOutputReader approach) to pin
+# the pure-python extraction logic. MoosePointSamplerSet is pure CSV parsing
+# and is characterized directly with synthesized MOOSE-style CSV files.
+#
+# These must remain GREEN through a pure refactor.
+
+import os
+
+import numpy as np
+import pytest
+
+from fiberis.moose import postprocessor
+from fiberis.moose.postprocessor import MooseOutputReader, MoosePointSamplerSet
+
+
+# ---------------------------------------------------------------------------
+# In-memory mesh fixtures for MooseOutputReader (avoids meshio / Exodus files)
+# ---------------------------------------------------------------------------
+
+class _FakeMesh:
+    def __init__(self, points, point_data, field_data=None, cell_data=None):
+        self.points = np.asarray(points, dtype=float)
+        self.point_data = point_data
+        self.field_data = field_data if field_data is not None else {}
+        self.cell_data = cell_data if cell_data is not None else {}
+
+
+def _reader_with_mesh(mesh):
+    """Construct a MooseOutputReader around a pre-built mesh, replaying the
+    time-step inference logic from __init__ without touching meshio."""
+    reader = MooseOutputReader.__new__(MooseOutputReader)
+    reader.mesh = mesh
+    reader.points = mesh.points
+    reader._kdtree = None
+    reader.time_steps = None
+    if mesh.field_data and "time_whole" in mesh.field_data:
+        reader.time_steps = np.array(mesh.field_data["time_whole"])
+        if reader.time_steps.ndim == 0:
+            reader.time_steps = np.array([reader.time_steps.item()])
+    elif mesh.point_data and mesh.point_data.keys():
+        first_var = next(iter(mesh.point_data))
+        pdata = mesh.point_data[first_var]
+        if isinstance(pdata, list):
+            reader.time_steps = np.arange(len(pdata))
+        elif isinstance(pdata, np.ndarray):
+            reader.time_steps = np.array([0.0])
+    return reader
+
+
+# Five points forming a small 2D mesh (z=0), matching the module's __main__.
+_POINTS = [[0, 0, 0], [1, 0, 0], [0, 1, 0], [1, 1, 0], [0.5, 0.5, 0.0]]
+
+
+def _steady_state_reader():
+    mesh = _FakeMesh(
+        _POINTS,
+        point_data={"diffused": np.array([0.0, 1.0, 0.0, 1.0, 0.5])},
+        field_data={},
+    )
+    return _reader_with_mesh(mesh)
+
+
+def _transient_reader():
+    # Two time steps, scalar nodal variable 'diffused'.
+    mesh = _FakeMesh(
+        _POINTS,
+        point_data={
+            "diffused": [
+                np.array([0.0, 1.0, 2.0, 3.0, 4.0]),
+                np.array([10.0, 11.0, 12.0, 13.0, 14.0]),
+            ]
+        },
+        field_data={"time_whole": [0.0, 0.5]},
+    )
+    return _reader_with_mesh(mesh)
+
+
+class TestMooseOutputReaderSteadyState:
+    def test_time_steps_inferred_as_single_zero(self):
+        reader = _steady_state_reader()
+        # No time_whole, point_data is an ndarray -> assume single step at t=0.
+        np.testing.assert_array_equal(reader.get_time_steps(), [0.0])
+
+    def test_nodal_variable_names(self):
+        assert _steady_state_reader().get_nodal_variable_names() == ["diffused"]
+
+    def test_cell_variable_names_empty(self):
+        assert _steady_state_reader().get_cell_variable_names() == []
+
+    def test_find_nearest_node_indices(self):
+        reader = _steady_state_reader()
+        # Query the exact center point and a corner.
+        idx = reader.find_nearest_node_indices([(0.5, 0.5), (0.0, 0.0)])
+        assert idx == [4, 0]
+
+    def test_find_nearest_node_indices_empty(self):
+        assert _steady_state_reader().find_nearest_node_indices([]) == []
+
+    def test_extract_point_data_dict_numpy(self):
+        reader = _steady_state_reader()
+        result = reader.extract_point_data_over_time(
+            "diffused", [(0.0, 0.0), (0.5, 0.5)], output_format="dict_numpy"
+        )
+        assert set(result.keys()) == {"point_0_node_0", "point_1_node_4"}
+        np.testing.assert_array_equal(result["point_0_node_0"], [0.0])
+        np.testing.assert_array_equal(result["point_1_node_4"], [0.5])
+
+    def test_extract_point_data_pandas_df(self):
+        reader = _steady_state_reader()
+        df = reader.extract_point_data_over_time(
+            "diffused", [(1.0, 1.0)], output_format="pandas_df"
+        )
+        # Node 3 is nearest (1,1). Index is the single time step [0.0].
+        assert list(df.index) == [0.0]
+        assert "point_0_node_3" in df.columns
+        assert df["point_0_node_3"].tolist() == [1.0]
+
+    def test_extract_missing_variable_returns_none(self):
+        reader = _steady_state_reader()
+        assert reader.extract_point_data_over_time("nope", [(0.0, 0.0)]) is None
+
+    def test_waterfall_single_2d_array(self):
+        reader = _steady_state_reader()
+        arr = reader.extract_line_data_for_waterfall(
+            "diffused", (0.0, 0.0), (1.0, 0.0), 2,
+            output_format="single_2d_array_time_vs_space",
+        )
+        # 1 time step x 2 line points -> shape (1, 2).
+        assert arr.shape == (1, 2)
+        # Endpoints (0,0)->node0=0.0 and (1,0)->node1=1.0.
+        np.testing.assert_array_equal(arr, [[0.0, 1.0]])
+
+
+class TestMooseOutputReaderTransient:
+    def test_time_steps_from_field_data(self):
+        reader = _transient_reader()
+        np.testing.assert_array_equal(reader.get_time_steps(), [0.0, 0.5])
+
+    def test_extract_point_data_over_two_steps(self):
+        reader = _transient_reader()
+        result = reader.extract_point_data_over_time(
+            "diffused", [(0.0, 0.0)], output_format="dict_numpy"
+        )
+        np.testing.assert_array_equal(result["point_0_node_0"], [0.0, 10.0])
+
+    def test_waterfall_dict_numpy_keyed_by_time(self):
+        reader = _transient_reader()
+        result = reader.extract_line_data_for_waterfall(
+            "diffused", (0.0, 0.0), (1.0, 0.0), 2, output_format="dict_numpy"
+        )
+        assert sorted(result.keys()) == [0.0, 0.5]
+        np.testing.assert_array_equal(result[0.0], [0.0, 1.0])
+        np.testing.assert_array_equal(result[0.5], [10.0, 11.0])
+
+    def test_waterfall_list_of_arrays(self):
+        reader = _transient_reader()
+        result = reader.extract_line_data_for_waterfall(
+            "diffused", (0.0, 0.0), (1.0, 0.0), 2, output_format="list_of_arrays"
+        )
+        assert isinstance(result, list)
+        assert len(result) == 2
+
+
+# ---------------------------------------------------------------------------
+# MoosePointSamplerSet -- pure CSV parsing
+# ---------------------------------------------------------------------------
+
+def _write_sampler_csv(path, header, rows):
+    lines = [",".join(header)]
+    for row in rows:
+        lines.append(",".join(str(v) for v in row))
+    path.write_text("\n".join(lines) + "\n")
+
+
+class TestMoosePointSamplerSet:
+    def test_loads_each_variable_column(self, tmp_path):
+        _write_sampler_csv(
+            tmp_path / "ps.csv",
+            ["time", "ppA", "ppB"],
+            [(0.0, 1.0, 4.0), (1.0, 2.0, 5.0), (2.0, 3.0, 6.0)],
+        )
+        s = MoosePointSamplerSet(str(tmp_path))
+        assert sorted(s.get_sampler_names()) == ["ppA", "ppB"]
+
+    def test_sampler_data_values(self, tmp_path):
+        _write_sampler_csv(
+            tmp_path / "ps.csv",
+            ["time", "ppA", "ppB"],
+            [(0.0, 1.0, 4.0), (1.0, 2.0, 5.0), (2.0, 3.0, 6.0)],
+        )
+        s = MoosePointSamplerSet(str(tmp_path))
+        ppA = s.get_sampler("ppA")
+        np.testing.assert_array_equal(ppA.taxis, [0.0, 1.0, 2.0])
+        np.testing.assert_array_equal(ppA.data, [1.0, 2.0, 3.0])
+        # Type used to hold the data.
+        assert type(ppA).__name__ == "Data1D_MOOSEps"
+
+    def test_get_sampler_missing_returns_none(self, tmp_path):
+        _write_sampler_csv(tmp_path / "ps.csv", ["time", "ppA"], [(0.0, 1.0)])
+        s = MoosePointSamplerSet(str(tmp_path))
+        assert s.get_sampler("nonexistent") is None
+
+    def test_numbered_vector_files_not_excluded_bug(self, tmp_path):
+        # NOTE: possible bug. The exclusion regex is r'.*?_\\d+\.csv$' with a
+        # doubled backslash, so '\\d' is treated as a literal backslash+d and
+        # never matches digit-numbered vector-sampler files. As a result a
+        # numbered file like 'vec_0000.csv' is NOT excluded and its columns are
+        # loaded as point samplers.
+        _write_sampler_csv(tmp_path / "ps.csv", ["time", "ppA"], [(0.0, 1.0)])
+        _write_sampler_csv(tmp_path / "vec_0000.csv", ["id", "vvar"], [(0, 9.0)])
+        s = MoosePointSamplerSet(str(tmp_path))
+        # 'vvar' from the numbered file leaks in alongside 'ppA'.
+        assert "vvar" in s.get_sampler_names()
+        assert "ppA" in s.get_sampler_names()
+
+    def test_missing_directory_yields_no_samplers(self, tmp_path):
+        s = MoosePointSamplerSet(str(tmp_path / "does_not_exist"))
+        assert s.get_sampler_names() == []
+
+    def test_empty_directory_yields_no_samplers(self, tmp_path):
+        s = MoosePointSamplerSet(str(tmp_path))
+        assert s.get_sampler_names() == []
+
+    def test_plot_all_samplers_saves_png(self, tmp_path):
+        _write_sampler_csv(
+            tmp_path / "ps.csv", ["time", "ppA"], [(0.0, 1.0), (1.0, 2.0)]
+        )
+        s = MoosePointSamplerSet(str(tmp_path))
+        save_dir = tmp_path / "plots"
+        s.plot_all_samplers(save_dir=str(save_dir), show_plots=False)
+        assert os.path.exists(os.path.join(str(save_dir), "sampler_ppA.png"))
+
+    def test_plot_all_samplers_no_samplers_noop(self, tmp_path):
+        s = MoosePointSamplerSet(str(tmp_path))  # empty dir -> no samplers
+        # Should simply return without error.
+        s.plot_all_samplers(save_dir=str(tmp_path / "plots"))
+        assert s.get_sampler_names() == []

--- a/tests/test_signal_utils_extended.py
+++ b/tests/test_signal_utils_extended.py
@@ -1,0 +1,389 @@
+# Characterization (golden-master) tests for fiberis.utils.signal_utils.
+#
+# These pin the CURRENT observable behavior of the signal-processing helpers
+# that are NOT already covered by tests/test_signal_utils.py. Golden values
+# were produced by RUNNING the code; they should survive a pure refactor.
+#
+# All randomness uses a FIXED seed so the golden numbers are reproducible.
+
+import datetime
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+from fiberis.utils import signal_utils as su
+
+
+# ---------------------------------------------------------------------------
+# Deterministic fixtures
+# ---------------------------------------------------------------------------
+
+FS = 100.0
+DT = 1.0 / FS
+
+
+@pytest.fixture
+def noisy_sine():
+    """5 Hz sine + Gaussian noise, fixed seed -> reproducible golden values."""
+    np.random.seed(42)
+    t = np.arange(0, 2, DT)
+    clean = np.sin(2 * np.pi * 5 * t)
+    noise = np.random.randn(len(t)) * 0.5
+    return t, clean, clean + noise
+
+
+# ---------------------------------------------------------------------------
+# Butterworth coefficient designers
+# ---------------------------------------------------------------------------
+
+def test_butter_bandpass_coeffs():
+    b, a = su.butter_bandpass(5.0, 15.0, 100.0, order=2)
+    npt.assert_allclose(b, [0.067455, 0.0, -0.134911, 0.0, 0.067455], atol=1e-6)
+    npt.assert_allclose(a, [1.0, -2.673579, 2.992362, -1.674577, 0.412802], atol=1e-6)
+
+
+def test_butter_lppass_coeffs():
+    b, a = su.butter_lppass(10.0, 100.0, order=2)
+    npt.assert_allclose(b, [0.067455, 0.134911, 0.067455], atol=1e-6)
+    npt.assert_allclose(a, [1.0, -1.142981, 0.412802], atol=1e-6)
+
+
+def test_butter_hppass_coeffs():
+    b, a = su.butter_hppass(10.0, 100.0, order=2)
+    npt.assert_allclose(b, [0.638946, -1.277891, 0.638946], atol=1e-6)
+    npt.assert_allclose(a, [1.0, -1.142981, 0.412802], atol=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Filters applied to data
+# ---------------------------------------------------------------------------
+
+def test_bpfilter_golden(noisy_sine):
+    _, _, sig = noisy_sine
+    y = su.bpfilter(sig, DT, 3.0, 7.0)
+    assert y.shape == sig.shape
+    npt.assert_allclose(np.sum(y), 2.900411, atol=1e-5)
+    npt.assert_allclose(
+        y[:5], [0.11353, 0.491637, 0.83192, 1.10011, 1.268529], atol=1e-5
+    )
+
+
+def test_lpfilter_golden(noisy_sine):
+    _, _, sig = noisy_sine
+    y = su.lpfilter(sig, DT, 10.0)
+    npt.assert_allclose(np.sum(y), -4.321422, atol=1e-5)
+    npt.assert_allclose(
+        y[:5], [0.24754, 0.548468, 0.825142, 1.04228, 1.176369], atol=1e-5
+    )
+
+
+def test_hpfilter_golden(noisy_sine):
+    _, _, sig = noisy_sine
+    y = su.hpfilter(sig, DT, 10.0)
+    npt.assert_allclose(np.sum(y), 0.23936, atol=1e-5)
+    npt.assert_allclose(
+        y[:5], [0.000817, -0.308583, 0.086487, 0.528252, -0.342389], atol=1e-5
+    )
+
+
+# ---------------------------------------------------------------------------
+# Amplitude spectrum
+# ---------------------------------------------------------------------------
+
+def test_amp_spectrum_peak_and_length():
+    t = np.arange(0, 2, DT)
+    clean = np.sin(2 * np.pi * 5 * t)
+    freqs, amps = su.amp_spectrum(clean, DT)
+    # Only positive (>=0) frequencies returned.
+    assert len(freqs) == 100
+    assert np.all(freqs >= 0)
+    peak_freq = freqs[np.argmax(amps)]
+    npt.assert_allclose(peak_freq, 5.0, atol=1e-6)
+    npt.assert_allclose(np.max(amps), 100.0, atol=1e-2)
+
+
+def test_amp_spectrum_ortho_norm_scales():
+    t = np.arange(0, 2, DT)
+    clean = np.sin(2 * np.pi * 5 * t)
+    _, amps_plain = su.amp_spectrum(clean, DT)
+    _, amps_ortho = su.amp_spectrum(clean, DT, norm="ortho")
+    # ortho norm divides by sqrt(N); N=200 here.
+    npt.assert_allclose(amps_ortho, amps_plain / np.sqrt(200), atol=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# rms
+# ---------------------------------------------------------------------------
+
+def test_rms_1d():
+    npt.assert_allclose(su.rms(np.array([3.0, 4.0])), 3.5355339059327378, atol=1e-12)
+
+
+def test_rms_axes():
+    m = np.array([[1.0, 2.0], [3.0, 4.0]])
+    npt.assert_allclose(su.rms(m, axis=0), [2.236068, 3.162278], atol=1e-6)
+    npt.assert_allclose(su.rms(m, axis=1), [1.581139, 3.535534], atol=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# phase_wrap
+# ---------------------------------------------------------------------------
+
+def test_phase_wrap_golden():
+    out = su.phase_wrap(np.array([0, np.pi, 2 * np.pi, 3 * np.pi, -np.pi]))
+    # np.angle wraps to (-pi, pi]; 2*pi -> 0, 3*pi -> pi, -pi -> -pi.
+    npt.assert_allclose(out, [0.0, np.pi, 0.0, np.pi, -np.pi], atol=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# matdatenum_to_pydatetime
+# ---------------------------------------------------------------------------
+
+def test_matdatenum_epoch():
+    assert su.matdatenum_to_pydatetime(719529) == datetime.datetime(1970, 1, 1)
+
+
+def test_matdatenum_recent():
+    assert su.matdatenum_to_pydatetime(738886) == datetime.datetime(2022, 12, 31)
+
+
+# ---------------------------------------------------------------------------
+# correlation_coefficient
+# ---------------------------------------------------------------------------
+
+def test_correlation_perfect():
+    a = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    n = np.array([2.0, 4.0, 6.0, 8.0, 10.0])
+    npt.assert_allclose(su.correlation_coefficient(a, n), 1.0, atol=1e-12)
+
+
+def test_correlation_mismatched_length_returns_none():
+    assert su.correlation_coefficient(np.array([1.0, 2.0]), np.array([1.0])) is None
+
+
+def test_correlation_empty_returns_none():
+    assert su.correlation_coefficient(np.array([]), np.array([])) is None
+
+
+def test_correlation_flat_equal_returns_one():
+    # Both constant AND equal -> returns 1.0 (zero-variance special case).
+    a = np.array([2.0, 2.0, 2.0])
+    assert su.correlation_coefficient(a, a) == 1.0
+
+
+def test_correlation_flat_one_side_returns_zero():
+    # One side constant -> denominator zero, numerator zero -> returns 0.0.
+    a = np.array([2.0, 2.0, 2.0])
+    n = np.array([1.0, 2.0, 3.0])
+    assert su.correlation_coefficient(a, n) == 0.0
+
+
+def test_correlation_random_golden():
+    np.random.seed(1)
+    a = np.random.randn(50)
+    n = np.random.randn(50)
+    npt.assert_allclose(su.correlation_coefficient(a, n), -0.02255187, atol=1e-7)
+
+
+# ---------------------------------------------------------------------------
+# Interpolation matrices
+# ---------------------------------------------------------------------------
+
+def test_get_interp_mat_linear():
+    m = su.get_interp_mat(3, 5, kind="linear")
+    expected = np.array(
+        [
+            [1.0, 0.0, 0.0],
+            [0.5, 0.5, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.5, 0.5],
+            [0.0, 0.0, 1.0],
+        ]
+    )
+    npt.assert_allclose(m, expected, atol=1e-9)
+
+
+def test_get_interp_mat_quadratic_rows_sum_to_one():
+    m = su.get_interp_mat(3, 5, kind="quadratic")
+    npt.assert_allclose(m.sum(axis=1), np.ones(5), atol=1e-9)
+
+
+def test_get_interp_mat_anchorx_linear_endpoints():
+    x = np.linspace(0, 10, 6)
+    ax = np.array([0.0, 5.0, 10.0])
+    m = su.get_interp_mat_anchorx(x, ax, kind="linear")
+    assert m.shape == (6, 3)
+    npt.assert_allclose(m[0], [1.0, 0.0, 0.0], atol=1e-9)
+    npt.assert_allclose(m[-1], [0.0, 0.0, 1.0], atol=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# get_smooth_curve
+# ---------------------------------------------------------------------------
+
+def test_get_smooth_curve_linear_golden():
+    np.random.seed(7)
+    x0 = np.linspace(0, 10, 50)
+    data = 2 * x0 + 1 + np.random.randn(50) * 0.1
+    anchor_x = np.linspace(0, 10, 4)
+    sm, solved = su.get_smooth_curve(x0, anchor_x, data, kind="linear")
+    assert len(sm) == 50
+    npt.assert_allclose(sm[:3], [1.021991, 1.426864, 1.831736], atol=1e-5)
+    npt.assert_allclose(
+        solved, [1.021991, 7.63491, 14.300678, 20.963986], atol=1e-5
+    )
+
+
+# ---------------------------------------------------------------------------
+# running_average
+# ---------------------------------------------------------------------------
+
+def test_running_average_odd_window():
+    d = np.arange(10, dtype=float)
+    ra = su.running_average(d, 3)
+    npt.assert_allclose(
+        ra, [0.5, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 8.5], atol=1e-9
+    )
+
+
+def test_running_average_even_window():
+    d = np.arange(10, dtype=float)
+    ra = su.running_average(d, 4)
+    npt.assert_allclose(
+        ra, [1.0, 1.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.0], atol=1e-9
+    )
+
+
+def test_running_average_nonpositive_window_returns_copy():
+    d = np.arange(10, dtype=float)
+    out = su.running_average(d, 0)
+    npt.assert_array_equal(out, d)
+    assert out is not d  # returns a copy
+
+
+def test_running_average_window_larger_than_data():
+    d = np.array([1.0, 2.0, 3.0])
+    out = su.running_average(d, 5)
+    npt.assert_allclose(out, [2.0, 2.0, 2.0], atol=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# xcor_match
+# ---------------------------------------------------------------------------
+
+def test_xcor_match_shifted_impulse():
+    a = np.array([0.0, 1.0, 0.0, 0.0, 0.0])
+    b = np.array([0.0, 0.0, 1.0, 0.0, 0.0])
+    npt.assert_allclose(su.xcor_match(a, b), 1.0, atol=1e-12)
+
+
+def test_xcor_match_identical_zero_lag():
+    a = np.array([0.0, 1.0, 0.0, 0.0, 0.0])
+    npt.assert_allclose(su.xcor_match(a, a), 0.0, atol=1e-12)
+
+
+def test_xcor_match_empty_returns_nan():
+    assert np.isnan(su.xcor_match(np.array([]), np.array([])))
+
+
+def test_xcor_match_unequal_length_returns_nan():
+    assert np.isnan(su.xcor_match(np.array([1.0, 2.0]), np.array([1.0])))
+
+
+def test_xcor_match_flat_returns_nan():
+    assert np.isnan(su.xcor_match(np.zeros(5), np.zeros(5)))
+
+
+# ---------------------------------------------------------------------------
+# datetime_interp
+# ---------------------------------------------------------------------------
+
+def test_datetime_interp_basic():
+    t0 = datetime.datetime(2023, 1, 1)
+    timex0 = [t0 + datetime.timedelta(seconds=s) for s in (0, 10, 20)]
+    y0 = np.array([0.0, 10.0, 20.0])
+    timex = [t0 + datetime.timedelta(seconds=s) for s in (5, 15)]
+    npt.assert_allclose(su.datetime_interp(timex, timex0, y0), [5.0, 15.0], atol=1e-9)
+
+
+def test_datetime_interp_empty():
+    out = su.datetime_interp([], [], np.array([]))
+    assert out.size == 0
+
+
+def test_datetime_interp_single_reference():
+    t0 = datetime.datetime(2023, 1, 1)
+    timex = [t0 + datetime.timedelta(seconds=s) for s in (5, 15)]
+    out = su.datetime_interp(timex, [t0], np.array([42.0]))
+    npt.assert_allclose(out, [42.0, 42.0], atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# fetch_timestamp_fast
+# ---------------------------------------------------------------------------
+
+def test_fetch_timestamp_fast_basic():
+    strs = [
+        "2023-01-01 00:00:00",
+        "2023-01-01 00:00:01",
+        "2023-01-01 00:00:02",
+        "2023-01-01 00:00:03",
+    ]
+    ts, t = su.fetch_timestamp_fast(strs, downsampling=1)
+    assert ts[0] == datetime.datetime(2023, 1, 1, 0, 0, 0)
+    npt.assert_allclose(t, [0.0, 1.0, 2.0, 3.0], atol=1e-9)
+
+
+def test_fetch_timestamp_fast_single():
+    ts, t = su.fetch_timestamp_fast(["2023-01-01 00:00:00"], downsampling=1)
+    assert ts[0] == datetime.datetime(2023, 1, 1, 0, 0, 0)
+    npt.assert_allclose(t, [0.0], atol=1e-12)
+
+
+def test_fetch_timestamp_fast_empty():
+    ts, t = su.fetch_timestamp_fast([])
+    assert ts == []
+    assert t.size == 0
+
+
+# ---------------------------------------------------------------------------
+# timeshift_xcor
+# ---------------------------------------------------------------------------
+
+def test_timeshift_xcor_detects_shift():
+    np.random.seed(11)
+    N = 100
+    base = np.sin(2 * np.pi * np.arange(N) / 20)
+    data2 = base
+    data1 = np.roll(base, 3)
+    ts, shifted = su.timeshift_xcor(data1, data2, winsize=20, step=2)
+    assert ts.shape == (N,)
+    assert shifted.shape == (N,)
+    # NOTE: golden values pin current behavior (sign/convention not asserted).
+    npt.assert_allclose(np.nanmean(ts), -2.574996, atol=1e-5)
+    npt.assert_allclose(
+        ts[:5],
+        [-2.999412, -2.99892, -2.998435, -2.998281, -2.999032],
+        atol=1e-5,
+    )
+    npt.assert_allclose(np.sum(shifted), 0.222961, atol=1e-5)
+
+
+def test_timeshift_xcor_empty():
+    ts, sd = su.timeshift_xcor(np.array([]), np.array([]), winsize=5)
+    assert ts.size == 0
+    assert sd.size == 0
+
+
+def test_timeshift_xcor_winsize_larger_than_data():
+    d = np.arange(10.0)
+    ts, sd = su.timeshift_xcor(d, d, winsize=20)
+    assert np.all(np.isnan(ts))
+    npt.assert_array_equal(sd, d)
+
+
+def test_timeshift_xcor_winsize_zero():
+    d = np.arange(10.0)
+    ts, sd = su.timeshift_xcor(d, d, winsize=0)
+    assert np.all(np.isnan(ts))

--- a/tests/test_simulator_core.py
+++ b/tests/test_simulator_core.py
@@ -1,0 +1,287 @@
+"""
+Characterization (golden-master) tests for the lightweight 1D simulator core:
+    - fiberis.simulator.core.pds   (PDS1D_SingleSource / PDS1D_MultiSource)
+    - fiberis.simulator.core.bcs   (BoundaryCondition)
+
+These tests pin the CURRENT behavior of the code so a pure refactor can be
+validated against them. Golden values were obtained by RUNNING the code on
+small deterministic problems, not by hand-derivation. Where the current
+behavior looks suspicious it is pinned anyway with a `# NOTE: possible bug`.
+
+Run:
+    cd /home/user/fibeRIS && python3 -m pytest tests/test_simulator_core.py -q
+"""
+
+import datetime
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+from fiberis.simulator.core import pds as pdsmod
+from fiberis.simulator.core.bcs import BoundaryCondition
+from fiberis.analyzer.Data1D.core1D import Data1D
+
+
+# --------------------------------------------------------------------------
+# Helpers
+# --------------------------------------------------------------------------
+def make_source(data=(0.0, 10.0, 10.0), taxis=(0.0, 5.0, 10.0)):
+    """A small real Data1D source object (provides get_value_by_time / taxis)."""
+    return Data1D(
+        data=np.asarray(data, dtype=float),
+        taxis=np.asarray(taxis, dtype=float),
+        start_time=datetime.datetime(2020, 1, 1),
+    )
+
+
+def make_single(lbc="Dirichlet", rbc="Dirichlet", nx=5, diff=1.0, sourceidx=2):
+    p = pdsmod.PDS1D_SingleSource()
+    p.set_mesh(np.linspace(0.0, float(nx - 1), nx))
+    p.set_source(make_source())
+    p.set_bcs(lbc, rbc)
+    p.set_initial(np.zeros(nx))
+    p.set_diffusivity(diff)
+    p.set_sourceidx(sourceidx)
+    p.set_t0(0.0)
+    return p
+
+
+# --------------------------------------------------------------------------
+# BoundaryCondition (bcs.py)
+# --------------------------------------------------------------------------
+class TestBoundaryCondition:
+    def test_dirichlet_apply(self):
+        A = np.array([[2.0, -1.0, 0.0], [-1.0, 2.0, -1.0], [0.0, -1.0, 2.0]])
+        b = np.array([1.0, 2.0, 3.0])
+        bc = BoundaryCondition(type="Dirichlet", value=5.0, idx=0)
+        bc.set_matrix(A, b)
+        bc.apply()
+        npt.assert_array_equal(A[0], np.array([1.0, 0.0, 0.0]))
+        npt.assert_array_equal(b, np.array([5.0, 2.0, 3.0]))
+
+    def test_neumann_apply_left(self):
+        A = np.array([[2.0, -1.0, 0.0], [-1.0, 2.0, -1.0], [0.0, -1.0, 2.0]])
+        b = np.array([1.0, 2.0, 3.0])
+        bc = BoundaryCondition(type="Neumann", value=0.0, idx=0)
+        bc.set_matrix(A, b)
+        bc.apply()
+        # NOTE: BoundaryCondition.apply() Neumann uses diag=+1, neighbour=-1.
+        # This is the OPPOSITE sign convention from the inline Neumann in
+        # matbuilder (diag=-1, neighbour=+1). Pinned as-is.
+        npt.assert_array_equal(A[0], np.array([1.0, -1.0, 0.0]))
+        npt.assert_array_equal(b, np.array([0.0, 2.0, 3.0]))
+
+    def test_neumann_apply_right(self):
+        A = np.array([[2.0, -1.0, 0.0], [-1.0, 2.0, -1.0], [0.0, -1.0, 2.0]])
+        b = np.array([1.0, 2.0, 3.0])
+        bc = BoundaryCondition(type="Neumann", value=0.0, idx=2)
+        bc.set_matrix(A, b)
+        bc.apply()
+        npt.assert_array_equal(A[2], np.array([0.0, -1.0, 1.0]))
+        npt.assert_array_equal(b, np.array([1.0, 2.0, 0.0]))
+
+    def test_set_matrix_nonsquare_raises(self):
+        bc = BoundaryCondition()
+        with pytest.raises(ValueError, match="not square"):
+            bc.set_matrix(np.zeros((2, 3)), np.zeros(2))
+
+    def test_set_matrix_vecB_not_vector_raises(self):
+        bc = BoundaryCondition()
+        with pytest.raises(ValueError, match="not a vector"):
+            bc.set_matrix(np.eye(2), np.zeros((2, 2)))
+
+    def test_set_matrix_size_mismatch_raises(self):
+        bc = BoundaryCondition()
+        with pytest.raises(ValueError, match="does not match"):
+            bc.set_matrix(np.eye(3), np.zeros(2))
+
+    def test_unknown_bc_type_raises(self):
+        bc = BoundaryCondition(type="foo", idx=0)
+        bc.set_matrix(np.eye(2), np.zeros(2))
+        with pytest.raises(ValueError, match="Unknown BC type"):
+            bc.apply()
+
+    def test_pml_type_is_noop(self):
+        A = np.eye(3)
+        b = np.zeros(3)
+        bc = BoundaryCondition(type="PML", idx=0)
+        bc.set_matrix(A, b)
+        # PML branch is `pass`; nothing changes and no error.
+        assert bc.apply() is None
+        npt.assert_array_equal(A, np.eye(3))
+
+
+# --------------------------------------------------------------------------
+# PDS1D_SingleSource: configuration / self-check (pds.py)
+# --------------------------------------------------------------------------
+class TestPDSSingleConfig:
+    def test_diffusivity_scalar_broadcast(self):
+        p = pdsmod.PDS1D_SingleSource()
+        p.set_mesh(np.linspace(0.0, 4.0, 5))
+        p.set_diffusivity(2.0)
+        npt.assert_array_equal(p.diffusivity, np.full(5, 2.0))
+
+    def test_diffusivity_array_ok(self):
+        p = pdsmod.PDS1D_SingleSource()
+        p.set_mesh(np.linspace(0.0, 4.0, 5))
+        p.set_diffusivity([1.0, 2.0, 3.0, 4.0, 5.0])
+        npt.assert_array_equal(p.diffusivity, np.array([1.0, 2.0, 3.0, 4.0, 5.0]))
+
+    def test_diffusivity_wrong_length_raises(self):
+        p = pdsmod.PDS1D_SingleSource()
+        p.set_mesh(np.linspace(0.0, 4.0, 5))
+        with pytest.raises(ValueError, match="single scalar value or an array"):
+            p.set_diffusivity([1.0, 2.0])
+
+    def test_self_check_all_pass(self):
+        p = make_single()
+        assert p.self_check() is True
+
+    def test_self_check_unset_fails(self):
+        p = pdsmod.PDS1D_SingleSource()
+        assert p.self_check() is False
+
+    def test_self_check_unknown_param(self):
+        p = make_single()
+        assert p.self_check("does_not_exist") is False
+
+    def test_check_mesh_too_short(self):
+        p = pdsmod.PDS1D_SingleSource()
+        p.set_mesh(np.array([1.0]))
+        ok, msg = p._check_mesh()
+        assert ok is False and "at least 2" in msg
+
+    def test_check_bc_invalid(self):
+        p = pdsmod.PDS1D_SingleSource()
+        p.set_bcs("Dirichlet", "Bogus")
+        ok, msg = p._check_bc()
+        assert ok is False and "Invalid right BC" in msg
+
+    def test_solve_returns_none_when_self_check_fails(self):
+        p = pdsmod.PDS1D_SingleSource()
+        # Nothing configured -> self_check fails -> solve() returns None early.
+        assert p.solve(dt=0.1, t_total=1.0) is None
+
+    def test_reset_clears_state(self):
+        p = make_single()
+        p.snapshot = "x"
+        p.taxis = "y"
+        p.history = ["a", "b"]
+        p.reset()
+        assert p.snapshot is None
+        assert p.taxis is None
+        assert p.history == []
+
+
+# --------------------------------------------------------------------------
+# PDS1D_SingleSource: full solve (golden master)
+# --------------------------------------------------------------------------
+class TestPDSSingleSolve:
+    def test_solve_shapes_and_taxis(self):
+        p = make_single()
+        p.solve(dt=0.5, t_total=2.0, mode="implicit")
+        # snapshot list starts with initial, then one append per accepted step.
+        assert p.snapshot.shape == (5, 5)
+        npt.assert_array_almost_equal(p.taxis, np.array([0.0, 0.5, 1.0, 1.5, 2.0]))
+
+    def test_solve_golden_values_dirichlet(self):
+        p = make_single()
+        p.solve(dt=0.5, t_total=2.0, mode="implicit")
+        npt.assert_allclose(
+            p.snapshot[-1],
+            np.array([0.0, 1.0625, 3.0, 1.0625, 0.0]),
+            rtol=0, atol=1e-9,
+        )
+
+    def test_solve_source_column_matches_source_values(self):
+        # Source idx is pinned to the interpolated source value at each step.
+        p = make_single()
+        p.solve(dt=0.5, t_total=2.0, mode="implicit")
+        npt.assert_allclose(
+            p.get_val_at_source_idx(),
+            np.array([0.0, 0.0, 1.0, 2.0, 3.0]),
+            rtol=0, atol=1e-9,
+        )
+
+    def test_solution_symmetry_dirichlet(self):
+        # Symmetric setup -> solution symmetric about the source index.
+        p = make_single()
+        p.solve(dt=0.5, t_total=2.0, mode="implicit")
+        final = p.snapshot[-1]
+        npt.assert_allclose(final, final[::-1], rtol=0, atol=1e-12)
+
+    def test_default_mode_is_implicit(self):
+        # Omitting `mode` defaults to the implicit solver; results match.
+        p_default = make_single()
+        p_default.solve(dt=0.5, t_total=2.0)
+        p_imp = make_single()
+        p_imp.solve(dt=0.5, t_total=2.0, mode="implicit")
+        npt.assert_allclose(p_default.snapshot, p_imp.snapshot, rtol=0, atol=1e-12)
+
+    def test_get_val_at_time(self):
+        p = make_single()
+        p.solve(dt=0.5, t_total=2.0, mode="implicit")
+        # Closest snapshot to t=1.0 is index 2.
+        npt.assert_allclose(p.get_val_at_time(1.0), p.snapshot[2], rtol=0, atol=1e-12)
+
+    def test_get_solution_tuple(self):
+        p = make_single()
+        p.solve(dt=0.5, t_total=2.0, mode="implicit")
+        snap, taxis = p.get_solution()
+        assert snap is p.snapshot and taxis is p.taxis
+
+
+# --------------------------------------------------------------------------
+# PDS1D_MultiSource (golden master)
+# --------------------------------------------------------------------------
+class TestPDSMultiSource:
+    def make_multi(self):
+        s1 = make_source(data=(0.0, 5.0, 5.0))
+        s2 = make_source(data=(0.0, -3.0, -3.0))
+        p = pdsmod.PDS1D_MultiSource()
+        p.set_mesh(np.linspace(0.0, 6.0, 7))
+        p.set_source([s1, s2])
+        p.set_bcs("Dirichlet", "Dirichlet")
+        p.set_initial(np.zeros(7))
+        p.set_diffusivity(1.0)
+        p.set_sourceidx([2, 4])
+        p.set_t0(0.0)
+        return p
+
+    def test_multi_solve_shape(self):
+        p = self.make_multi()
+        p.solve(dt=0.5, t_total=1.5, mode="implicit")
+        assert p.snapshot.shape == (4, 7)
+        npt.assert_array_almost_equal(p.taxis, np.array([0.0, 0.5, 1.0, 1.5]))
+
+    def test_multi_solve_golden_final(self):
+        p = self.make_multi()
+        p.solve(dt=0.5, t_total=1.5, mode="implicit")
+        npt.assert_allclose(
+            p.snapshot[-1],
+            np.array([0.0, 0.3125, 1.0, 0.125, -0.6, -0.1875, 0.0]),
+            rtol=0, atol=1e-9,
+        )
+
+    def test_multi_source_columns_pinned(self):
+        p = self.make_multi()
+        p.solve(dt=0.5, t_total=1.5, mode="implicit")
+        npt.assert_allclose(
+            p.get_val_at_idx(2), np.array([0.0, 0.0, 0.5, 1.0]), rtol=0, atol=1e-9
+        )
+        npt.assert_allclose(
+            p.get_val_at_idx(4), np.array([0.0, 0.0, -0.3, -0.6]), rtol=0, atol=1e-9
+        )
+
+    def test_multi_sourceidx_is_ndarray(self):
+        p = self.make_multi()
+        # PDS1D_MultiSource.set_sourceidx converts to a numpy array.
+        assert isinstance(p.sourceidx, np.ndarray)
+        npt.assert_array_equal(p.sourceidx, np.array([2, 4]))
+
+    def test_multi_check_source_requires_list(self):
+        p = pdsmod.PDS1D_MultiSource()
+        p.set_source(make_source())  # a single Data1D, not a list
+        ok, msg = p._check_source()
+        assert ok is False and "must be a list" in msg

--- a/tests/test_simulator_optimizer.py
+++ b/tests/test_simulator_optimizer.py
@@ -1,0 +1,103 @@
+"""
+Characterization (golden-master) tests for the time-sampling optimizer:
+    - fiberis.simulator.optimizer.tso  (adjust_dt, time_sampling_optimizer)
+
+These exercise the real numerics; tso has no external dependencies, so a
+lightweight fake pds object (only the attributes/methods tso touches) is
+sufficient. Golden values obtained by RUNNING the code.
+
+Run:
+    cd /home/user/fibeRIS && python3 -m pytest tests/test_simulator_optimizer.py -q
+"""
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+from fiberis.simulator.optimizer import tso
+
+
+def test_import_smoke():
+    assert hasattr(tso, "time_sampling_optimizer")
+    assert hasattr(tso, "adjust_dt")
+
+
+# --------------------------------------------------------------------------
+# adjust_dt
+# --------------------------------------------------------------------------
+class TestAdjustDt:
+    def test_error_equals_tol_keeps_safety_factor(self):
+        # error == tol -> ratio == 1 -> dt * safety_factor (0.9).
+        assert tso.adjust_dt(1.0, 1e-3) == pytest.approx(0.9)
+
+    def test_error_larger_than_tol_shrinks(self):
+        # Pinned golden: dt=1, error=1e-2, p=2, tol=1e-3, sf=0.9.
+        assert tso.adjust_dt(1.0, 1e-2) == pytest.approx(0.28460498941515416, rel=1e-12)
+
+    def test_tiny_error_treated_as_ratio_one(self):
+        # error < 1e-14 -> ratio forced to 1.0 -> 0.9.
+        assert tso.adjust_dt(1.0, 1e-16) == pytest.approx(0.9)
+
+    def test_clamp_to_max_dt(self):
+        # Large growth is clamped to max_dt (default 40).
+        assert tso.adjust_dt(100.0, 1e-9) == pytest.approx(40.0)
+
+    def test_clamp_to_min_dt(self):
+        # Large error forces shrink, clamped to min_dt (default 1e-4).
+        assert tso.adjust_dt(1e-6, 1.0) == pytest.approx(1e-4)
+
+    def test_custom_kwargs_override(self):
+        # safety_factor and max_dt overridable via kwargs.
+        out = tso.adjust_dt(10.0, 1e-9, safety_factor=0.5, max_dt=100.0)
+        # ratio capped by tol/error huge -> dt*0.5*ratio clamped to max_dt=100.
+        assert out == pytest.approx(100.0)
+
+
+# --------------------------------------------------------------------------
+# time_sampling_optimizer
+# --------------------------------------------------------------------------
+class FakePDS:
+    """Minimal stand-in exposing only what time_sampling_optimizer uses."""
+
+    def __init__(self):
+        self.snapshot = [np.zeros(3)]
+        self.taxis = [0.0]
+
+    def record_log(self, *args):
+        pass
+
+
+class TestTimeSamplingOptimizer:
+    def test_accept_when_error_below_tol(self):
+        fp = FakePDS()
+        full = np.array([1.0, 2.0, 3.0])
+        half = np.array([1.0, 2.0, 3.0])  # error == 0 -> accept
+        next_dt = tso.time_sampling_optimizer(fp, full, half, 0.5)
+        # Accepted: snapshot/taxis appended.
+        assert len(fp.snapshot) == 2
+        npt.assert_array_equal(fp.snapshot[-1], full)
+        assert fp.taxis == [0.0, 0.5]
+        # error < 1e-14 -> ratio 1 -> next dt = 0.5 * 0.9 = 0.45.
+        assert next_dt == pytest.approx(0.45)
+
+    def test_reject_when_error_above_tol(self):
+        fp = FakePDS()
+        full = np.array([1.0, 2.0, 3.0])
+        half = np.array([2.0, 4.0, 6.0])  # error == 1.0 -> reject
+        next_dt = tso.time_sampling_optimizer(fp, full, half, 0.5)
+        # Rejected: snapshot/taxis unchanged.
+        assert len(fp.snapshot) == 1
+        assert fp.taxis == [0.0]
+        # Golden next dt for error=1.0 from dt=0.5.
+        assert next_dt == pytest.approx(0.014230249470757706, rel=1e-12)
+
+    def test_error_at_exactly_tol_is_accepted(self):
+        # tol default 1e-3; construct vectors with relative error exactly 1e-3.
+        fp = FakePDS()
+        full = np.array([1000.0, 0.0, 0.0])
+        half = np.array([999.0, 0.0, 0.0])  # ||diff||/||full|| = 1/1000 = 1e-3
+        err = np.linalg.norm(full - half) / np.linalg.norm(full)
+        assert err == pytest.approx(1e-3)
+        tso.time_sampling_optimizer(fp, full, half, 0.5)
+        # error <= tol -> accepted.
+        assert len(fp.snapshot) == 2

--- a/tests/test_simulator_solver.py
+++ b/tests/test_simulator_solver.py
@@ -1,0 +1,254 @@
+"""
+Characterization (golden-master) tests for the 1D simulator solver layer:
+    - fiberis.simulator.solver.matbuilder      (matrix assembly + PML)
+    - fiberis.simulator.solver.PDESolver_IMP   (implicit / linear solve)
+    - fiberis.simulator.solver.PDESolver_EXP   (explicit Jacobi iteration)
+
+Golden values obtained by RUNNING the code on small deterministic problems.
+
+Run:
+    cd /home/user/fibeRIS && python3 -m pytest tests/test_simulator_solver.py -q
+"""
+
+import datetime
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+from fiberis.simulator.core import pds as pdsmod
+from fiberis.simulator.solver import matbuilder
+from fiberis.simulator.solver.PDESolver_IMP import solver_implicit
+from fiberis.simulator.solver.PDESolver_EXP import solver_explicit
+from fiberis.analyzer.Data1D.core1D import Data1D
+
+
+def make_source(data=(0.0, 10.0, 10.0), taxis=(0.0, 5.0, 10.0)):
+    return Data1D(
+        data=np.asarray(data, dtype=float),
+        taxis=np.asarray(taxis, dtype=float),
+        start_time=datetime.datetime(2020, 1, 1),
+    )
+
+
+def make_single(lbc="Neumann", rbc="Neumann", nx=5, diff=1.0, sourceidx=2):
+    """Configured PDS object primed for a single matrix-builder call (1 step)."""
+    p = pdsmod.PDS1D_SingleSource()
+    p.set_mesh(np.linspace(0.0, float(nx - 1), nx))
+    p.set_source(make_source())
+    p.set_bcs(lbc, rbc)
+    p.set_initial(np.zeros(nx))
+    p.set_diffusivity(diff)
+    p.set_sourceidx(sourceidx)
+    p.set_t0(0.0)
+    # Prime the transient state matbuilder reads (normally set up in solve()).
+    p.taxis = [0.0]
+    p.snapshot = [np.zeros(nx)]
+    return p
+
+
+# --------------------------------------------------------------------------
+# PDESolver_IMP.solver_implicit
+# --------------------------------------------------------------------------
+class TestImplicitSolver:
+    A = np.array([[2.0, -1.0, 0.0], [-1.0, 2.0, -1.0], [0.0, -1.0, 2.0]])
+    b = np.array([1.0, 2.0, 3.0])
+    expected = np.array([2.5, 4.0, 3.5])
+
+    def test_numpy_solver(self):
+        x = solver_implicit(self.A.copy(), self.b.copy(), solver="numpy")
+        npt.assert_allclose(x, self.expected, rtol=0, atol=1e-12)
+
+    def test_direct_solver(self):
+        x = solver_implicit(self.A.copy(), self.b.copy(), solver="direct")
+        npt.assert_allclose(x, self.expected, rtol=0, atol=1e-12)
+
+    def test_scipy_solver(self):
+        x = solver_implicit(self.A.copy(), self.b.copy(), solver="scipy")
+        npt.assert_allclose(x, self.expected, rtol=0, atol=1e-12)
+
+    def test_default_solver_is_scipy(self):
+        # Default kwarg solver='scipy'; sparse spsolve gives the same answer.
+        x = solver_implicit(self.A.copy(), self.b.copy())
+        npt.assert_allclose(x, self.expected, rtol=0, atol=1e-12)
+
+    def test_invalid_solver_raises(self):
+        with pytest.raises(ValueError, match="Invalid solver type"):
+            solver_implicit(self.A.copy(), self.b.copy(), solver="bogus")
+
+
+# --------------------------------------------------------------------------
+# PDESolver_EXP.solver_explicit (Jacobi)
+# --------------------------------------------------------------------------
+class TestExplicitSolver:
+    def test_jacobi_diagonally_dominant(self):
+        A = np.array([[4.0, 1.0, 0.0], [1.0, 5.0, 1.0], [0.0, 1.0, 3.0]])
+        b = np.array([5.0, 7.0, 4.0])
+        x = solver_explicit(A, b)
+        # Jacobi should converge to the true linear-system solution.
+        npt.assert_allclose(x, np.linalg.solve(A, b), rtol=0, atol=1e-8)
+
+    def test_identity_matrix(self):
+        A = np.eye(4)
+        b = np.array([1.0, -2.0, 3.0, 4.0])
+        x = solver_explicit(A, b)
+        npt.assert_allclose(x, b, rtol=0, atol=1e-12)
+
+    def test_non_convergent_returns_after_max_iter(self):
+        # Strongly non-diagonally-dominant -> Jacobi diverges; the function does
+        # NOT raise, it returns the last iterate after max_iter.
+        # NOTE: possible bug -- silent return on non-convergence.
+        A = np.array([[1.0, 5.0], [5.0, 1.0]])
+        b = np.array([1.0, 1.0])
+        x = solver_explicit(A, b, max_iter=5)
+        assert x.shape == (2,)
+        assert np.all(np.isfinite(x))
+
+
+# --------------------------------------------------------------------------
+# matbuilder.matrix_builder_1d_single_source
+# --------------------------------------------------------------------------
+class TestMatBuilderSingle:
+    def test_assembly_neumann_golden(self):
+        p = make_single(lbc="Neumann", rbc="Neumann", nx=5, diff=1.0, sourceidx=2)
+        A, b = matbuilder.matrix_builder_1d_single_source(p, 0.5)
+        expected_A = np.array(
+            [
+                [-1.0, 1.0, 0.0, 0.0, 0.0],
+                [-0.5, 2.0, -0.5, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 0.0, 0.0],
+                [0.0, 0.0, -0.5, 2.0, -0.5],
+                [0.0, 0.0, 0.0, 1.0, -1.0],
+            ]
+        )
+        npt.assert_allclose(A, expected_A, rtol=0, atol=1e-12)
+        # b is the previous snapshot (all zeros) with source value at sourceidx.
+        # At t=0 the source interpolates to 0.0.
+        npt.assert_allclose(b, np.zeros(5), rtol=0, atol=1e-12)
+
+    def test_assembly_shapes(self):
+        p = make_single(nx=6)
+        A, b = matbuilder.matrix_builder_1d_single_source(p, 0.3)
+        assert A.shape == (6, 6)
+        assert b.shape == (6,)
+
+    def test_source_row_is_identity(self):
+        # The source row is overwritten: zeroed then diagonal set to 1.
+        p = make_single(sourceidx=2)
+        A, _ = matbuilder.matrix_builder_1d_single_source(p, 0.5)
+        expected_row = np.zeros(5)
+        expected_row[2] = 1.0
+        npt.assert_array_equal(A[2], expected_row)
+
+    def test_source_value_in_b(self):
+        # Prime taxis so the source interpolates to a nonzero value.
+        p = make_single(sourceidx=2)
+        p.taxis = [5.0]  # source = 10.0 at t=5
+        A, b = matbuilder.matrix_builder_1d_single_source(p, 0.5)
+        assert b[2] == pytest.approx(10.0)
+
+    def test_dirichlet_boundary_rows(self):
+        p = make_single(lbc="Dirichlet", rbc="Dirichlet", nx=5, sourceidx=2)
+        A, b = matbuilder.matrix_builder_1d_single_source(p, 0.5)
+        assert A[0, 0] == pytest.approx(1.0)
+        assert A[-1, -1] == pytest.approx(1.0)
+        assert b[0] == pytest.approx(0.0)
+        assert b[-1] == pytest.approx(0.0)
+
+    def test_pml_adds_to_diagonal(self):
+        p = make_single(sourceidx=2)
+        A0, _ = matbuilder.matrix_builder_1d_single_source(p, 0.5, pml_thickness=0.0)
+        # Re-prime (matbuilder mutates the source row but reads snapshot copy).
+        p2 = make_single(sourceidx=2)
+        Apml, _ = matbuilder.matrix_builder_1d_single_source(
+            p2, 0.5, pml_thickness=2.0, sigma_max=3.0
+        )
+        # PML increases diagonal entries near the boundaries.
+        assert Apml[0, 0] >= A0[0, 0]
+
+
+# --------------------------------------------------------------------------
+# matbuilder.matrix_builder_1d_multi_source
+# --------------------------------------------------------------------------
+class TestMatBuilderMulti:
+    def make_multi(self):
+        s1 = make_source(data=(0.0, 5.0, 5.0))
+        s2 = make_source(data=(0.0, -3.0, -3.0))
+        p = pdsmod.PDS1D_MultiSource()
+        p.set_mesh(np.linspace(0.0, 6.0, 7))
+        p.set_source([s1, s2])
+        p.set_bcs("Dirichlet", "Dirichlet")
+        p.set_initial(np.zeros(7))
+        p.set_diffusivity(1.0)
+        p.set_sourceidx([2, 4])
+        p.set_t0(0.0)
+        p.taxis = [5.0]  # so sources interpolate to 5.0 and -3.0
+        p.snapshot = [np.zeros(7)]
+        return p
+
+    def test_multi_source_rows_and_values(self):
+        p = self.make_multi()
+        A, b = matbuilder.matrix_builder_1d_multi_source(p, 0.5)
+        assert A.shape == (7, 7) and b.shape == (7,)
+        # Each source row is identity at its index.
+        for idx in (2, 4):
+            row = np.zeros(7)
+            row[idx] = 1.0
+            npt.assert_array_equal(A[idx], row)
+        assert b[2] == pytest.approx(5.0)
+        assert b[4] == pytest.approx(-3.0)
+
+
+# --------------------------------------------------------------------------
+# matbuilder.build_pml_sigma
+# --------------------------------------------------------------------------
+class TestBuildPMLSigma:
+    def test_zero_thickness_all_zero(self):
+        mesh = np.linspace(0.0, 10.0, 11)
+        sigma = matbuilder.build_pml_sigma(mesh, 0.0, 2.0)
+        npt.assert_array_equal(sigma, np.zeros(11))
+
+    def test_symmetric_ramp(self):
+        mesh = np.linspace(0.0, 10.0, 11)
+        sigma = matbuilder.build_pml_sigma(mesh, 3.0, 2.0)
+        expected = np.array(
+            [2.0, 2.0 / 3.0 * 2, 2.0 / 3.0, 0, 0, 0, 0, 0, 2.0 / 3.0, 4.0 / 3.0, 2.0]
+        )
+        npt.assert_allclose(sigma, expected, rtol=0, atol=1e-12)
+        # Boundaries get max sigma; interior is zero.
+        assert sigma[0] == pytest.approx(2.0)
+        assert sigma[-1] == pytest.approx(2.0)
+        assert sigma[5] == pytest.approx(0.0)
+
+
+# --------------------------------------------------------------------------
+# Cross-check: implicit vs explicit through a full solve
+# --------------------------------------------------------------------------
+class TestImplicitVsExplicit:
+    def _solve(self, mode):
+        s = make_source()
+        p = pdsmod.PDS1D_SingleSource()
+        p.set_mesh(np.linspace(0.0, 4.0, 5))
+        p.set_source(s)
+        p.set_bcs("Dirichlet", "Dirichlet")
+        p.set_initial(np.zeros(5))
+        p.set_diffusivity(1.0)
+        p.set_sourceidx(2)
+        p.set_t0(0.0)
+        p.solve(dt=0.2, t_total=1.0, mode=mode)
+        return p
+
+    def test_implicit_and_explicit_agree(self):
+        pi = self._solve("implicit")
+        pe = self._solve("explicit")
+        assert pi.snapshot.shape == pe.snapshot.shape
+        # Jacobi (explicit) solves the same linear system to tight tolerance.
+        npt.assert_allclose(pi.snapshot, pe.snapshot, rtol=0, atol=1e-6)
+
+    def test_implicit_golden_final(self):
+        pi = self._solve("implicit")
+        npt.assert_allclose(
+            pi.snapshot[-1],
+            np.array([0.0, 0.4301541, 1.6, 0.4301541, 0.0]),
+            rtol=0, atol=1e-6,
+        )

--- a/tests/test_syn_utils.py
+++ b/tests/test_syn_utils.py
@@ -1,0 +1,107 @@
+# Characterization tests for fiberis.utils.syn_utils.gen_discrete_time_series.
+
+import datetime
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+from fiberis.utils import syn_utils as syn
+
+
+# ---------------------------------------------------------------------------
+# Random mode (seeded -> reproducible)
+# ---------------------------------------------------------------------------
+
+def test_random_seeded_golden():
+    t, x, st = syn.gen_discrete_time_series(
+        s=5, random=True, seed=123, start_time=datetime.datetime(2023, 1, 1)
+    )
+    npt.assert_array_equal(t, [0, 1, 2, 3, 4])
+    npt.assert_allclose(
+        x,
+        [0.69646919, 0.28613933, 0.22685145, 0.55131477, 0.71946897],
+        atol=1e-8,
+    )
+    assert st == datetime.datetime(2023, 1, 1)
+
+
+def test_random_default_time_axis_is_arange():
+    t, x, _ = syn.gen_discrete_time_series(s=4, random=True, seed=0)
+    npt.assert_array_equal(t, [0, 1, 2, 3])
+    assert len(x) == 4
+
+
+def test_random_custom_time_axis():
+    t, x, _ = syn.gen_discrete_time_series(
+        s=4, random=True, seed=0, t=np.array([10.0, 20.0, 30.0, 40.0])
+    )
+    npt.assert_array_equal(t, [10.0, 20.0, 30.0, 40.0])
+    npt.assert_allclose(
+        x, [0.5488135, 0.71518937, 0.60276338, 0.54488318], atol=1e-8
+    )
+
+
+def test_random_default_start_time_is_now():
+    before = datetime.datetime.now()
+    _, _, st = syn.gen_discrete_time_series(s=3, random=True, seed=1)
+    after = datetime.datetime.now()
+    assert before <= st <= after
+
+
+# ---------------------------------------------------------------------------
+# User-defined data mode
+# ---------------------------------------------------------------------------
+
+def test_user_defined_data():
+    t, x, st = syn.gen_discrete_time_series(
+        s=3,
+        random=False,
+        x=np.array([1.0, 2.0, 3.0]),
+        start_time=datetime.datetime(2023, 1, 1),
+    )
+    npt.assert_array_equal(t, [0, 1, 2])
+    npt.assert_array_equal(x, [1.0, 2.0, 3.0])
+    assert st == datetime.datetime(2023, 1, 1)
+
+
+def test_user_defined_missing_x_raises():
+    with pytest.raises(ValueError):
+        syn.gen_discrete_time_series(s=3, random=False)
+
+
+def test_user_defined_wrong_size_x_raises():
+    with pytest.raises(ValueError):
+        syn.gen_discrete_time_series(s=3, random=False, x=np.array([1.0, 2.0]))
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+def test_mismatched_t_size_raises():
+    with pytest.raises(ValueError):
+        syn.gen_discrete_time_series(s=5, random=True, t=np.arange(3))
+
+
+def test_invalid_start_time_type_raises():
+    with pytest.raises(ValueError):
+        syn.gen_discrete_time_series(s=3, random=True, start_time="2023-01-01")
+
+
+# ---------------------------------------------------------------------------
+# File saving
+# ---------------------------------------------------------------------------
+
+def test_save_to_npz(tmp_path):
+    fname = str(tmp_path / "series.npz")
+    t, x, st = syn.gen_discrete_time_series(
+        s=4,
+        random=True,
+        seed=5,
+        start_time=datetime.datetime(2023, 6, 1),
+        filename=fname,
+    )
+    loaded = np.load(fname, allow_pickle=True)
+    npt.assert_array_equal(loaded["taxis"], t)
+    npt.assert_allclose(loaded["data"], x, atol=1e-12)

--- a/tests/test_tensor1d.py
+++ b/tests/test_tensor1d.py
@@ -1,33 +1,140 @@
-"""Characterization tests for fiberis.analyzer.TensorProcessor.coreT1D.
+"""Characterization tests for fiberis.analyzer.TensorProcessor.coreT1D.Tensor1D.
 
-IMPORTANT CURRENT-BEHAVIOR NOTE:
-    coreT1D.py uses the type hint ``Tuple[int, int]`` (lines 122 and 155) but
-    only imports ``Optional, Union, List, Any, Dict`` from ``typing`` -- it does
-    NOT import ``Tuple``. Because the annotation is evaluated at class-definition
-    time, the *module itself fails to import* with a ``NameError`` before the
-    ``Tensor1D`` class can ever be constructed.
-
-    This is a genuine bug. Per the characterization-test contract we pin the
-    CURRENT observable behavior (import fails) rather than the intended behavior.
-    When the bug is fixed (e.g. by adding ``Tuple`` to the typing import), the
-    ``test_module_currently_fails_to_import`` test below will start failing and
-    should be replaced with real behavioral tests of ``Tensor1D``.
+History: coreT1D.py previously failed to import because it used ``Tuple[...]``
+annotations without importing ``Tuple`` from ``typing``. That defect has been
+fixed (see docs/modernization_notes.md, bug #1), so these tests now exercise the
+real behavior of the ``Tensor1D`` class instead of pinning the import failure.
 """
 
-import importlib
+import datetime  # noqa: F401  (kept for parity with sibling tensor tests)
 
+import numpy as np
 import pytest
 
-
-def test_module_currently_fails_to_import():
-    # NOTE: possible bug -- `Tuple` is used in annotations but never imported,
-    # so importing the module raises NameError at class-definition time.
-    with pytest.raises(NameError) as excinfo:
-        importlib.import_module("fiberis.analyzer.TensorProcessor.coreT1D")
-    assert "Tuple" in str(excinfo.value)
+from fiberis.analyzer.TensorProcessor.coreT1D import Tensor1D
 
 
-def test_tensor1d_class_is_unimportable():
-    # The class cannot be imported either, for the same reason.
-    with pytest.raises(NameError):
-        from fiberis.analyzer.TensorProcessor.coreT1D import Tensor1D  # noqa: F401
+@pytest.fixture
+def sample_tensor():
+    """A 4-point field of 2x2 tensors with distinct, easy-to-track components."""
+    daxis = np.array([0.0, 1.0, 2.0, 3.0])
+    data = np.zeros((4, 2, 2))
+    data[:, 0, 0] = [11, 12, 13, 14]  # xx
+    data[:, 0, 1] = [21, 22, 23, 24]  # xy
+    data[:, 1, 0] = [31, 32, 33, 34]  # yx
+    data[:, 1, 1] = [41, 42, 43, 44]  # yy
+    t = Tensor1D(name="sample")
+    t.set_daxis(daxis).set_data(data).set_dim(2)
+    return t
+
+
+class TestInit:
+    def test_default_name_and_history(self):
+        t = Tensor1D()
+        assert t.name == "Default Tensor1D Data"
+        assert t.data is None and t.daxis is None and t.dim is None
+        assert len(t.history.records) == 1
+
+    def test_explicit_name(self):
+        t = Tensor1D(name="mytensor")
+        assert t.name == "mytensor"
+
+
+class TestSetters:
+    def test_set_data_requires_3d(self):
+        with pytest.raises(TypeError):
+            Tensor1D().set_data(np.zeros((4, 2)))
+
+    def test_set_data_requires_square(self):
+        with pytest.raises(ValueError):
+            Tensor1D().set_data(np.zeros((4, 2, 3)))
+
+    def test_set_data_infers_dim(self):
+        t = Tensor1D().set_data(np.zeros((5, 3, 3)))
+        assert t.dim == 3
+
+    def test_set_data_is_defensive_copy(self):
+        arr = np.zeros((2, 2, 2))
+        t = Tensor1D().set_data(arr)
+        arr[0, 0, 0] = 99.0
+        assert t.data[0, 0, 0] == 0.0  # copy, not a shared reference
+
+    def test_set_data_daxis_length_mismatch(self):
+        t = Tensor1D().set_daxis(np.array([0.0, 1.0]))
+        with pytest.raises(ValueError):
+            t.set_data(np.zeros((3, 2, 2)))
+
+    def test_set_daxis_requires_1d(self):
+        with pytest.raises(TypeError):
+            Tensor1D().set_daxis(np.zeros((2, 2)))
+
+    def test_set_dim_rejects_nonpositive(self):
+        with pytest.raises(TypeError):
+            Tensor1D().set_dim(0)
+
+    def test_set_dim_mismatch_with_data(self):
+        t = Tensor1D().set_data(np.zeros((2, 2, 2)))
+        with pytest.raises(ValueError):
+            t.set_dim(3)
+
+    def test_set_name_type_check(self):
+        with pytest.raises(TypeError):
+            Tensor1D().set_name(123)
+
+    def test_setters_return_self_for_chaining(self, sample_tensor):
+        assert isinstance(sample_tensor, Tensor1D)
+        assert sample_tensor.dim == 2
+
+
+class TestIO:
+    def test_savez_requires_complete_state(self, tmp_path):
+        with pytest.raises(ValueError):
+            Tensor1D().savez(str(tmp_path / "x.npz"))
+
+    def test_savez_load_roundtrip(self, sample_tensor, tmp_path):
+        path = str(tmp_path / "tensor")  # extension auto-appended
+        sample_tensor.savez(path)
+        reloaded = Tensor1D().load_npz(path)
+        np.testing.assert_array_equal(reloaded.data, sample_tensor.data)
+        np.testing.assert_array_equal(reloaded.daxis, sample_tensor.daxis)
+        assert reloaded.dim == 2
+        assert reloaded.name == "sample"
+
+
+class TestGetComponent:
+    def test_string_components(self, sample_tensor):
+        np.testing.assert_array_equal(sample_tensor.get_component("xx"), [11, 12, 13, 14])
+        np.testing.assert_array_equal(sample_tensor.get_component("xy"), [21, 22, 23, 24])
+        np.testing.assert_array_equal(sample_tensor.get_component("yx"), [31, 32, 33, 34])
+        np.testing.assert_array_equal(sample_tensor.get_component("yy"), [41, 42, 43, 44])
+
+    def test_tuple_component(self, sample_tensor):
+        np.testing.assert_array_equal(sample_tensor.get_component((1, 1)), [41, 42, 43, 44])
+
+    def test_invalid_string(self, sample_tensor):
+        with pytest.raises(ValueError):
+            sample_tensor.get_component("qq")
+
+    def test_out_of_bounds_index(self, sample_tensor):
+        with pytest.raises(IndexError):
+            sample_tensor.get_component((2, 2))  # dim is 2
+
+    def test_requires_data(self):
+        with pytest.raises(ValueError):
+            Tensor1D(dim=2).get_component("xx")
+
+
+class TestPlotAndStr:
+    def test_plot_component_default_path(self, sample_tensor):
+        # Headless Agg backend is configured in conftest; default call must not raise.
+        assert sample_tensor.plot_component("xx") is None
+
+    def test_plot_requires_daxis(self):
+        t = Tensor1D()
+        t.set_data(np.zeros((2, 2, 2)))
+        with pytest.raises(ValueError):
+            t.plot_component("xx")
+
+    def test_str_summary(self, sample_tensor):
+        s = str(sample_tensor)
+        assert "Tensor1D" in s and "(4, 2, 2)" in s and "sample" in s

--- a/tests/test_tensor1d.py
+++ b/tests/test_tensor1d.py
@@ -1,0 +1,33 @@
+"""Characterization tests for fiberis.analyzer.TensorProcessor.coreT1D.
+
+IMPORTANT CURRENT-BEHAVIOR NOTE:
+    coreT1D.py uses the type hint ``Tuple[int, int]`` (lines 122 and 155) but
+    only imports ``Optional, Union, List, Any, Dict`` from ``typing`` -- it does
+    NOT import ``Tuple``. Because the annotation is evaluated at class-definition
+    time, the *module itself fails to import* with a ``NameError`` before the
+    ``Tensor1D`` class can ever be constructed.
+
+    This is a genuine bug. Per the characterization-test contract we pin the
+    CURRENT observable behavior (import fails) rather than the intended behavior.
+    When the bug is fixed (e.g. by adding ``Tuple`` to the typing import), the
+    ``test_module_currently_fails_to_import`` test below will start failing and
+    should be replaced with real behavioral tests of ``Tensor1D``.
+"""
+
+import importlib
+
+import pytest
+
+
+def test_module_currently_fails_to_import():
+    # NOTE: possible bug -- `Tuple` is used in annotations but never imported,
+    # so importing the module raises NameError at class-definition time.
+    with pytest.raises(NameError) as excinfo:
+        importlib.import_module("fiberis.analyzer.TensorProcessor.coreT1D")
+    assert "Tuple" in str(excinfo.value)
+
+
+def test_tensor1d_class_is_unimportable():
+    # The class cannot be imported either, for the same reason.
+    with pytest.raises(NameError):
+        from fiberis.analyzer.TensorProcessor.coreT1D import Tensor1D  # noqa: F401

--- a/tests/test_tensor2d.py
+++ b/tests/test_tensor2d.py
@@ -1,0 +1,425 @@
+"""Characterization tests for fiberis.analyzer.TensorProcessor.coreT2D.Tensor2D.
+
+These pin the CURRENT observable behavior of the Tensor2D class (time- and
+depth-varying 2x2 tensor fields) as a refactoring safety net.
+
+Golden values were obtained by RUNNING the code. Small deterministic synthetic
+tensors with analytically known projections/eigen-structure are used so the
+characterization is strong. Where current behavior looks questionable it is
+pinned anyway and annotated with ``# NOTE: possible bug``.
+"""
+
+import copy
+import datetime
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+from fiberis.analyzer.TensorProcessor.coreT2D import Tensor2D
+from fiberis.analyzer.Data2D.core2D import Data2D
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+@pytest.fixture
+def diag_tensor(sample_start_time):
+    """A single (depth, time) diagonal tensor diag(2, 1).
+
+    Known projection: n^T T n = 2 cos^2(theta) + 1 sin^2(theta) for a
+    direction at angle theta from +x.
+    """
+    data = np.zeros((1, 1, 2, 2))
+    data[0, 0] = np.array([[2.0, 0.0], [0.0, 1.0]])
+    return Tensor2D(
+        data=data,
+        taxis=np.array([0.0]),
+        daxis=np.array([5.0]),
+        dim=2,
+        start_time=sample_start_time,
+        name="diag",
+    )
+
+
+@pytest.fixture
+def field_tensor(sample_start_time):
+    """A (2 depth, 4 time) field. Tensor at depth d is diag(1+d, 0)."""
+    n_d, n_t = 2, 4
+    data = np.zeros((n_d, n_t, 2, 2))
+    for d in range(n_d):
+        for t in range(n_t):
+            data[d, t] = np.array([[1.0 + d, 0.2], [0.2, 0.5 * t]])
+    return Tensor2D(
+        data=data,
+        taxis=np.array([0.0, 1.0, 2.0, 3.0]),
+        daxis=np.array([10.0, 20.0]),
+        dim=2,
+        start_time=sample_start_time,
+        name="field",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Construction / setters
+# ---------------------------------------------------------------------------
+class TestConstruction:
+    def test_default_construction_is_empty(self):
+        t = Tensor2D()
+        assert t.data is None
+        assert t.taxis is None
+        assert t.daxis is None
+        assert t.dim is None
+        assert t.start_time is None
+        assert t.name is None
+
+    def test_set_data_infers_dim(self):
+        t = Tensor2D().set_data(np.zeros((1, 1, 2, 2)))
+        assert t.dim == 2
+
+    def test_set_data_rejects_non_4d(self):
+        with pytest.raises(TypeError):
+            Tensor2D().set_data(np.zeros((2, 2, 2)))
+
+    def test_set_data_rejects_non_square(self):
+        with pytest.raises(ValueError):
+            Tensor2D().set_data(np.zeros((1, 1, 2, 3)))
+
+    def test_set_data_does_not_defensively_copy(self):
+        # NOTE: possible bug -- Tensor2D.set_data stores the array by reference
+        # (unlike CoreTensor.set_data which copies). External mutation leaks in.
+        arr = np.zeros((1, 1, 2, 2))
+        t = Tensor2D().set_data(arr)
+        arr[0, 0, 0, 0] = 99.0
+        assert t.data[0, 0, 0, 0] == 99.0
+
+    def test_setters_return_self(self):
+        t = Tensor2D()
+        assert t.set_taxis(np.array([0.0])) is t
+        assert t.set_daxis(np.array([1.0])) is t
+        assert t.set_dim(2) is t
+        assert t.set_name("x") is t
+        st = datetime.datetime(2023, 1, 1)
+        assert t.set_start_time(st) is t
+
+
+# ---------------------------------------------------------------------------
+# get_component
+# ---------------------------------------------------------------------------
+class TestGetComponent:
+    def test_xx_component(self, field_tensor):
+        c = field_tensor.get_component("xx")
+        assert isinstance(c, Data2D)
+        # depth 0 -> 1.0 across all times, depth 1 -> 2.0
+        npt.assert_array_equal(c.data, np.array([[1.0] * 4, [2.0] * 4]))
+        assert c.name == "field_xx"
+
+    def test_offdiag_components(self, field_tensor):
+        npt.assert_array_equal(
+            field_tensor.get_component("xy").data, np.full((2, 4), 0.2)
+        )
+        npt.assert_array_equal(
+            field_tensor.get_component("yx").data, np.full((2, 4), 0.2)
+        )
+
+    def test_yy_component_varies_with_time(self, field_tensor):
+        # yy = 0.5 * t
+        npt.assert_array_equal(
+            field_tensor.get_component("yy").data,
+            np.array([[0.0, 0.5, 1.0, 1.5]] * 2),
+        )
+
+    def test_tuple_component(self, field_tensor):
+        npt.assert_array_equal(
+            field_tensor.get_component((0, 1)).data, np.full((2, 4), 0.2)
+        )
+
+    def test_component_passes_axes_through(self, field_tensor):
+        c = field_tensor.get_component("xx")
+        npt.assert_array_equal(c.taxis, field_tensor.taxis)
+        npt.assert_array_equal(c.daxis, field_tensor.daxis)
+        assert c.start_time == field_tensor.start_time
+
+    def test_invalid_component_string(self, field_tensor):
+        with pytest.raises(ValueError):
+            field_tensor.get_component("zz")
+
+    def test_component_requires_data(self):
+        with pytest.raises(ValueError):
+            Tensor2D().get_component("xx")
+
+
+# ---------------------------------------------------------------------------
+# get_directional_component  (latest-commit feature)
+# ---------------------------------------------------------------------------
+class TestDirectionalComponent:
+    def test_angle_0_from_x(self, diag_tensor):
+        # direction +x -> T_xx = 2
+        assert diag_tensor.get_directional_component(0).data[0, 0] == 2.0
+
+    def test_angle_90_from_x(self, diag_tensor):
+        # direction +y -> T_yy = 1
+        npt.assert_allclose(
+            diag_tensor.get_directional_component(90).data[0, 0], 1.0, atol=1e-12
+        )
+
+    def test_angle_45_from_x(self, diag_tensor):
+        # 2 cos^2(45) + 1 sin^2(45) = 1.5
+        npt.assert_allclose(
+            diag_tensor.get_directional_component(45).data[0, 0], 1.5, atol=1e-12
+        )
+
+    def test_in_radians(self, diag_tensor):
+        npt.assert_allclose(
+            diag_tensor.get_directional_component(np.pi / 2, in_radians=True).data[0, 0],
+            1.0,
+            atol=1e-12,
+        )
+
+    def test_reference_axis_y_angle_0(self, diag_tensor):
+        # angle 0 from +y -> direction +y -> 1.0
+        npt.assert_allclose(
+            diag_tensor.get_directional_component(0, reference_axis="y").data[0, 0],
+            1.0,
+            atol=1e-12,
+        )
+
+    def test_reference_axis_y_angle_90(self, diag_tensor):
+        # angle 90 from +y -> direction +x -> 2.0
+        npt.assert_allclose(
+            diag_tensor.get_directional_component(90, reference_axis="y").data[0, 0],
+            2.0,
+            atol=1e-12,
+        )
+
+    def test_clockwise_from_x(self, diag_tensor):
+        # clockwise 90 from +x -> direction (0,-1) -> T_yy = 1.0
+        npt.assert_allclose(
+            diag_tensor.get_directional_component(90, clockwise=True).data[0, 0],
+            1.0,
+            atol=1e-12,
+        )
+
+    def test_reference_axis_case_insensitive(self, diag_tensor):
+        npt.assert_allclose(
+            diag_tensor.get_directional_component(0, reference_axis="Y").data[0, 0],
+            1.0,
+            atol=1e-12,
+        )
+
+    def test_returns_data2d_with_axes(self, diag_tensor):
+        dc = diag_tensor.get_directional_component(0)
+        assert isinstance(dc, Data2D)
+        npt.assert_array_equal(dc.taxis, diag_tensor.taxis)
+        npt.assert_array_equal(dc.daxis, diag_tensor.daxis)
+        assert dc.start_time == diag_tensor.start_time
+
+    def test_default_output_name(self, diag_tensor):
+        assert (
+            diag_tensor.get_directional_component(0).name
+            == "diag_directional_component"
+        )
+
+    def test_custom_output_name(self, diag_tensor):
+        assert diag_tensor.get_directional_component(0, name="custom").name == "custom"
+
+    def test_invalid_reference_axis(self, diag_tensor):
+        with pytest.raises(ValueError):
+            diag_tensor.get_directional_component(0, reference_axis="z")
+
+    def test_requires_2d(self):
+        t = Tensor2D(
+            data=np.zeros((1, 1, 3, 3)),
+            taxis=np.array([0.0]),
+            daxis=np.array([0.0]),
+            dim=3,
+        )
+        with pytest.raises(ValueError):
+            t.get_directional_component(0)
+
+    def test_requires_data(self):
+        with pytest.raises(ValueError):
+            Tensor2D().get_directional_component(0)
+
+    def test_field_projection_matches_components(self, field_tensor):
+        # Projecting at 0 deg from +x must equal the xx component everywhere.
+        proj = field_tensor.get_directional_component(0).data
+        npt.assert_allclose(proj, field_tensor.get_component("xx").data, atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# Rotation
+# ---------------------------------------------------------------------------
+class TestRotation:
+    def test_rotate_returns_self(self, field_tensor):
+        assert field_tensor.rotate_tensor(0) is field_tensor
+
+    def test_rotate_requires_data(self):
+        with pytest.raises(ValueError):
+            Tensor2D(dim=2).rotate_tensor(10)
+
+    def test_rotate_unsupported_dimension(self):
+        t = Tensor2D(data=np.zeros((1, 1, 3, 3)), dim=3)
+        with pytest.raises(ValueError):
+            t.rotate_tensor(10)
+
+    def test_rotate_90_uniaxial_current_behavior(self, sample_start_time):
+        # NOTE: possible bug -- rotate_tensor uses
+        #   np.einsum('ik,dtkj,lj->dtil', R, data, R.T)
+        # which evaluates to R @ T @ R (NOT R @ T @ R^T as the docstring
+        # claims). For T = [[1,0],[0,0]] rotated 90deg the active rotation
+        # R T R^T would give [[0,0],[0,1]], but the current code returns
+        # [[0,0],[0,-1]]. We pin the CURRENT (buggy) result.
+        data = np.zeros((1, 1, 2, 2))
+        data[0, 0] = np.array([[1.0, 0.0], [0.0, 0.0]])
+        t = Tensor2D(
+            data=data,
+            taxis=np.array([0.0]),
+            daxis=np.array([0.0]),
+            dim=2,
+            start_time=sample_start_time,
+        )
+        t.rotate_tensor(90)
+        npt.assert_allclose(
+            t.data[0, 0], np.array([[0.0, 0.0], [0.0, -1.0]]), atol=1e-12
+        )
+
+    def test_rotate_degrees_equals_radians(self, sample_start_time):
+        data = np.zeros((1, 1, 2, 2))
+        data[0, 0] = np.array([[1.0, 0.3], [0.3, -2.0]])
+        t_deg = Tensor2D(
+            data=data.copy(),
+            taxis=np.array([0.0]),
+            daxis=np.array([0.0]),
+            dim=2,
+        )
+        t_rad = Tensor2D(
+            data=data.copy(),
+            taxis=np.array([0.0]),
+            daxis=np.array([0.0]),
+            dim=2,
+        )
+        t_deg.rotate_tensor(90)
+        t_rad.rotate_tensor(np.pi / 2, in_radians=True)
+        npt.assert_allclose(t_deg.data, t_rad.data, atol=1e-12)
+
+    def test_rotate_360_is_identity(self, sample_start_time):
+        data = np.zeros((1, 1, 2, 2))
+        data[0, 0] = np.array([[1.0, 0.3], [0.3, -2.0]])
+        t = Tensor2D(
+            data=data.copy(),
+            taxis=np.array([0.0]),
+            daxis=np.array([0.0]),
+            dim=2,
+        )
+        original = t.data.copy()
+        t.rotate_tensor(360)
+        npt.assert_allclose(t.data, original, atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# Cropping
+# ---------------------------------------------------------------------------
+class TestSelectTime:
+    def test_select_time_floats(self, field_tensor):
+        t = copy.deepcopy(field_tensor)
+        t.select_time(1.0, 2.0)
+        npt.assert_array_equal(t.taxis, np.array([1.0, 2.0]))
+        assert t.data.shape == (2, 2, 2, 2)
+
+    def test_select_time_datetimes(self, field_tensor, sample_start_time):
+        t = copy.deepcopy(field_tensor)
+        t.select_time(
+            sample_start_time + datetime.timedelta(seconds=1),
+            sample_start_time + datetime.timedelta(seconds=2),
+        )
+        npt.assert_array_equal(t.taxis, np.array([1.0, 2.0]))
+
+    def test_select_time_inclusive_bounds(self, field_tensor):
+        t = copy.deepcopy(field_tensor)
+        t.select_time(0.0, 3.0)
+        npt.assert_array_equal(t.taxis, field_tensor.taxis)
+
+    def test_select_time_returns_self(self, field_tensor):
+        t = copy.deepcopy(field_tensor)
+        assert t.select_time(0.0, 1.0) is t
+
+    def test_select_time_requires_start_time(self):
+        t = Tensor2D(
+            data=np.zeros((1, 2, 2, 2)),
+            taxis=np.array([0.0, 1.0]),
+            daxis=np.array([0.0]),
+            dim=2,
+        )
+        with pytest.raises(ValueError):
+            t.select_time(0, 1)
+
+
+class TestSelectDepth:
+    def test_select_depth(self, field_tensor):
+        t = copy.deepcopy(field_tensor)
+        t.select_depth(15.0, 25.0)
+        npt.assert_array_equal(t.daxis, np.array([20.0]))
+        assert t.data.shape == (1, 4, 2, 2)
+
+    def test_select_depth_inclusive(self, field_tensor):
+        t = copy.deepcopy(field_tensor)
+        t.select_depth(10.0, 20.0)
+        npt.assert_array_equal(t.daxis, field_tensor.daxis)
+
+    def test_select_depth_returns_self(self, field_tensor):
+        t = copy.deepcopy(field_tensor)
+        assert t.select_depth(0.0, 100.0) is t
+
+    def test_select_depth_requires_data(self):
+        with pytest.raises(ValueError):
+            Tensor2D(daxis=np.array([1.0])).select_depth(0, 1)
+
+
+# ---------------------------------------------------------------------------
+# I/O
+# ---------------------------------------------------------------------------
+class TestIO:
+    def test_save_load_roundtrip(self, field_tensor, tmp_path):
+        fname = str(tmp_path / "t2d.npz")
+        assert field_tensor.savez(fname) is None
+        loaded = Tensor2D().load_npz(fname)
+        npt.assert_array_equal(loaded.data, field_tensor.data)
+        npt.assert_array_equal(loaded.taxis, field_tensor.taxis)
+        npt.assert_array_equal(loaded.daxis, field_tensor.daxis)
+        assert loaded.dim == 2
+        assert loaded.name == "field"
+        assert loaded.start_time == field_tensor.start_time
+
+    def test_savez_appends_extension(self, field_tensor, tmp_path):
+        fname = str(tmp_path / "noext")
+        field_tensor.savez(fname)
+        assert (tmp_path / "noext.npz").exists()
+
+    def test_savez_requires_essentials(self, tmp_path):
+        with pytest.raises(ValueError):
+            Tensor2D().savez(str(tmp_path / "empty.npz"))
+
+    def test_load_appends_extension(self, field_tensor, tmp_path):
+        field_tensor.savez(str(tmp_path / "x.npz"))
+        loaded = Tensor2D().load_npz(str(tmp_path / "x"))
+        assert loaded.dim == 2
+
+
+# ---------------------------------------------------------------------------
+# __str__
+# ---------------------------------------------------------------------------
+class TestStr:
+    def test_str_populated(self, field_tensor):
+        s = str(field_tensor)
+        assert "Tensor2D Object: field" in s
+        assert "Data Shape: (2, 4, 2, 2)" in s
+        assert "Time Axis Size: 4" in s
+        assert "Depth Axis Size: 2" in s
+        assert "Tensor Dimension: 2" in s
+
+    def test_str_empty(self):
+        s = str(Tensor2D())
+        assert "Tensor2D Object: Unnamed" in s
+        assert "Data Shape: N/A" in s
+        assert "Start Time: N/A" in s

--- a/tests/test_tensor_core_extended.py
+++ b/tests/test_tensor_core_extended.py
@@ -1,0 +1,257 @@
+"""Characterization tests for fiberis.analyzer.TensorProcessor.coreT.CoreTensor.
+
+These pin the CURRENT observable behavior of the base CoreTensor class as a
+safety net before refactoring. They intentionally complement (and do not
+duplicate) the existing tests in tests/test_tensor.py.
+
+Golden values were obtained by RUNNING the code, not by guessing. Where the
+current behavior looks questionable it is pinned anyway and annotated with a
+``# NOTE: possible bug`` comment.
+"""
+
+import datetime
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+from fiberis.analyzer.TensorProcessor.coreT import CoreTensor
+
+
+# ---------------------------------------------------------------------------
+# Construction / defaults
+# ---------------------------------------------------------------------------
+class TestConstruction:
+    def test_default_construction_is_empty(self):
+        ct = CoreTensor()
+        assert ct.data is None
+        assert ct.taxis is None
+        assert ct.dim is None
+        assert ct.start_time is None
+        assert ct.name == "Default Tensor Data"
+
+    def test_named_construction(self):
+        ct = CoreTensor(name="my_tensor")
+        assert ct.name == "my_tensor"
+
+    def test_history_records_on_init(self):
+        ct = CoreTensor()
+        # An InfoManagementSystem record is created on init.
+        assert ct.history is not None
+
+
+# ---------------------------------------------------------------------------
+# Setters: validation and method chaining
+# ---------------------------------------------------------------------------
+class TestSetters:
+    def test_set_data_infers_dim_when_unset(self):
+        ct = CoreTensor()
+        ret = ct.set_data(np.zeros((3, 3, 4)))
+        assert ret is ct  # method chaining
+        assert ct.dim == 3
+        assert ct.data.shape == (3, 3, 4)
+
+    def test_set_data_defensive_copy(self):
+        arr = np.zeros((2, 2, 2))
+        ct = CoreTensor().set_data(arr)
+        arr[0, 0, 0] = 99.0
+        # CoreTensor.set_data copies, so external mutation does not leak in.
+        assert ct.data[0, 0, 0] == 0.0
+
+    def test_set_data_rejects_non_ndarray(self):
+        with pytest.raises(TypeError):
+            CoreTensor().set_data([[1, 2], [3, 4]])
+
+    def test_set_data_rejects_non_3d(self):
+        with pytest.raises(ValueError):
+            CoreTensor().set_data(np.zeros((2, 2)))
+
+    def test_set_data_rejects_non_square(self):
+        with pytest.raises(ValueError):
+            CoreTensor().set_data(np.zeros((2, 3, 4)))
+
+    def test_set_data_dim_mismatch(self):
+        ct = CoreTensor(dim=2)
+        with pytest.raises(ValueError):
+            ct.set_data(np.zeros((3, 3, 4)))
+
+    def test_set_data_taxis_length_mismatch(self):
+        ct = CoreTensor()
+        ct.set_taxis(np.array([0.0, 1.0, 2.0]))
+        with pytest.raises(ValueError):
+            ct.set_data(np.zeros((2, 2, 5)))
+
+    def test_set_taxis_defensive_copy_and_chaining(self):
+        arr = np.array([0.0, 1.0, 2.0])
+        ct = CoreTensor()
+        ret = ct.set_taxis(arr)
+        assert ret is ct
+        arr[0] = 99.0
+        assert ct.taxis[0] == 0.0
+
+    def test_set_taxis_rejects_non_ndarray(self):
+        with pytest.raises(TypeError):
+            CoreTensor().set_taxis([0, 1, 2])
+
+    def test_set_taxis_rejects_non_1d(self):
+        with pytest.raises(ValueError):
+            CoreTensor().set_taxis(np.zeros((2, 2)))
+
+    def test_set_taxis_rejects_decreasing(self):
+        with pytest.raises(ValueError):
+            CoreTensor().set_taxis(np.array([0.0, 2.0, 1.0]))
+
+    def test_set_taxis_allows_repeated_values(self):
+        # diff == 0 is NOT < 0, so equal consecutive values are accepted.
+        ct = CoreTensor().set_taxis(np.array([0.0, 1.0, 1.0, 2.0]))
+        npt.assert_array_equal(ct.taxis, np.array([0.0, 1.0, 1.0, 2.0]))
+
+    def test_set_taxis_length_mismatch_with_data(self):
+        ct = CoreTensor().set_data(np.zeros((2, 2, 3)))
+        with pytest.raises(ValueError):
+            ct.set_taxis(np.array([0.0, 1.0]))
+
+    def test_set_dim_rejects_non_python_int(self):
+        # numpy integer is NOT a python int -> TypeError under current behavior.
+        with pytest.raises(TypeError):
+            CoreTensor().set_dim(np.int64(2))  # NOTE: possible bug (np.int rejected)
+
+    def test_set_dim_accepts_python_int(self):
+        ct = CoreTensor().set_dim(3)
+        assert ct.dim == 3
+
+    def test_set_dim_mismatch_with_data(self):
+        ct = CoreTensor().set_data(np.zeros((2, 2, 2)))
+        with pytest.raises(ValueError):
+            ct.set_dim(3)
+
+    def test_set_start_time_validation(self):
+        with pytest.raises(TypeError):
+            CoreTensor().set_start_time("2023-01-01")
+        st = datetime.datetime(2023, 1, 1)
+        ct = CoreTensor().set_start_time(st)
+        assert ct.start_time == st
+
+    def test_set_name_validation(self):
+        with pytest.raises(TypeError):
+            CoreTensor().set_name(123)
+        ct = CoreTensor().set_name("foo")
+        assert ct.name == "foo"
+
+
+# ---------------------------------------------------------------------------
+# Rotation
+# ---------------------------------------------------------------------------
+class TestRotation:
+    def test_rotate_returns_none(self):
+        ct = CoreTensor(data=np.zeros((2, 2, 1)), taxis=np.array([0.0]), dim=2)
+        assert ct.rotate_tensor(0) is None
+
+    def test_rotate_accepts_int_degree(self):
+        ct = CoreTensor(data=np.zeros((2, 2, 1)), taxis=np.array([0.0]), dim=2)
+        ct.rotate_tensor(0)  # int accepted, no error
+
+    def test_rotate_rejects_non_numeric(self):
+        ct = CoreTensor(data=np.zeros((2, 2, 1)), taxis=np.array([0.0]), dim=2)
+        with pytest.raises(TypeError):
+            ct.rotate_tensor("90")
+
+    def test_rotate_requires_data(self):
+        with pytest.raises(ValueError):
+            CoreTensor(dim=2).rotate_tensor(0.1)
+
+    def test_rotate_2d_90deg_uniaxial(self):
+        # [[1,0],[0,0]] rotated 90deg -> [[0,0],[0,1]]
+        data = np.zeros((2, 2, 1))
+        data[0, 0, 0] = 1.0
+        ct = CoreTensor(data=data, taxis=np.array([0.0]), dim=2)
+        ct.rotate_tensor(np.pi / 2)
+        npt.assert_allclose(
+            ct.data[:, :, 0], np.array([[0.0, 0.0], [0.0, 1.0]]), atol=1e-10
+        )
+
+    def test_rotate_3d_around_z_90deg(self):
+        # 3D rotation is around Z; uniaxial x stress goes to y.
+        data = np.zeros((3, 3, 1))
+        data[0, 0, 0] = 1.0
+        ct = CoreTensor(data=data, taxis=np.array([0.0]), dim=3)
+        ct.rotate_tensor(np.pi / 2)
+        expected = np.array(
+            [[0.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 0.0]]
+        )
+        npt.assert_allclose(ct.data[:, :, 0], expected, atol=1e-10)
+
+    def test_rotate_unsupported_dimension(self):
+        ct = CoreTensor(data=np.zeros((4, 4, 1)), taxis=np.array([0.0]), dim=4)
+        with pytest.raises(ValueError):
+            ct.rotate_tensor(0.1)
+
+    def test_rotate_diagonal_invariant_under_full_turn(self):
+        data = np.zeros((2, 2, 1))
+        data[0, 0, 0] = 3.0
+        data[1, 1, 0] = -2.0
+        ct = CoreTensor(data=data, taxis=np.array([0.0]), dim=2)
+        original = ct.data.copy()
+        ct.rotate_tensor(2 * np.pi)
+        npt.assert_allclose(ct.data, original, atol=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# I/O round-trip
+# ---------------------------------------------------------------------------
+class TestIO:
+    def _make(self, start_time=None, name="io_tensor"):
+        data = np.arange(2 * 2 * 3, dtype=float).reshape(2, 2, 3)
+        taxis = np.array([0.0, 1.0, 2.0])
+        return CoreTensor(
+            data=data, taxis=taxis, dim=2, start_time=start_time, name=name
+        )
+
+    def test_save_load_roundtrip_with_start_time(self, tmp_path, sample_start_time):
+        ct = self._make(start_time=sample_start_time)
+        fname = str(tmp_path / "rt.npz")
+        ret = ct.savez(fname)
+        assert ret is ct
+        loaded = CoreTensor().load_npz(fname)
+        npt.assert_array_equal(loaded.data, ct.data)
+        npt.assert_array_equal(loaded.taxis, ct.taxis)
+        assert loaded.dim == 2
+        assert loaded.name == "io_tensor"
+        assert loaded.start_time == sample_start_time
+
+    def test_save_load_roundtrip_without_start_time(self, tmp_path):
+        ct = self._make(start_time=None)
+        fname = str(tmp_path / "rt2")  # no extension; auto-appended
+        ct.savez(fname)
+        loaded = CoreTensor().load_npz(fname)
+        assert loaded.start_time is None
+        npt.assert_array_equal(loaded.data, ct.data)
+
+    def test_savez_appends_extension(self, tmp_path):
+        ct = self._make()
+        fname = str(tmp_path / "noext")
+        ct.savez(fname)
+        assert (tmp_path / "noext.npz").exists()
+
+    def test_savez_requires_essential_attributes(self, tmp_path):
+        with pytest.raises(ValueError):
+            CoreTensor().savez(str(tmp_path / "empty.npz"))
+
+    def test_load_missing_file_raises(self):
+        with pytest.raises(FileNotFoundError):
+            CoreTensor().load_npz("/nonexistent/path/missing.npz")
+
+    def test_load_accepts_path_with_extension(self, tmp_path):
+        ct = self._make()
+        fname = str(tmp_path / "withext.npz")
+        ct.savez(fname)
+        loaded = CoreTensor().load_npz(fname)
+        assert loaded.dim == 2
+
+    def test_load_missing_required_key_raises_keyerror(self, tmp_path):
+        # An .npz that exists but lacks the required 'data'/'taxis'/'dim' keys
+        # is re-raised as a KeyError by load_npz.
+        fname = str(tmp_path / "bad.npz")
+        np.savez(fname, foo=np.array([1, 2, 3]))
+        with pytest.raises(KeyError):
+            CoreTensor().load_npz(fname)


### PR DESCRIPTION
## Summary

This PR adds a comprehensive characterization (golden-master) test suite across the entire fibeRIS package to establish a safety net for ongoing modernization work. Additionally, it fixes two import bugs that were preventing modules from loading.

## Key Changes

### Test Suite (New)
- **Characterization tests**: Added ~6,500 lines of golden-master tests across 25+ test files covering:
  - `test_moose_model_builder.py` (951 lines) — MOOSE model construction and rendering
  - `test_core1D_extended.py` (695 lines) — Data1D methods (load_npz, crop, select_time, etc.)
  - `test_core2D_extended.py` (518 lines) — Data2D cropping, shifting, merging, plotting
  - `test_tensor2d.py` (425 lines) — Tensor2D construction, projections, eigenvalues
  - `test_io_readers.py` (396 lines) — Reader classes for HFTS2, Mariner, MOOSE formats
  - `test_signal_utils_extended.py` (389 lines) — Butterworth filters and signal processing
  - Plus 18 additional test files covering simulator, geometry, tensor, config, and utility modules

- **Test infrastructure**: Added `conftest.py` with shared fixtures and `docs/modernization_notes.md` documenting the strategy

- **CI/CD**: Added `.github/workflows/ci.yml` to run the test suite on every push and PR

### Bug Fixes
- **`coreT1D.py`**: Added missing `Tuple` import from `typing` module (line 9)
  - This was causing import failures when the module was loaded
  
- **`reader_mariner_3d.py`**: Fixed import path from `fiberis.analyzer.Geometry3D` to `fiberis.analyzer.Geometry3D.coreG3D` (line 9)
  - Corrects module structure to match actual package layout
  
- **`reader_mariner_gauge1d.py`**: Fixed import path from `fiberis.analyzer.Data1D` to `fiberis.analyzer.Data1D.Data1D_Gauge` (line 8)
  - Corrects module structure to match actual package layout

### Configuration
- **`pyproject.toml`**: Updated pytest configuration to enable the new test suite

## Implementation Details

The characterization tests follow a "safety net first, refactor second" strategy:
- All golden values were obtained by **running the actual code**, not by hand-derivation or guessing
- Tests pin the *current* observable behavior, allowing behavior-preserving refactors to remain green
- Where current behavior appears questionable, it is still pinned with a `# NOTE: possible bug` annotation
- Tests use small, deterministic synthetic data with analytically known properties for strong characterization

The test suite covers:
- Construction and initialization
- Data I/O (load/save roundtrips)
- Cropping, shifting, filtering, and merging operations
- Mathematical operations (projections, eigenvalues, interpolation)
- Plotting and visualization
- Error handling and guard paths
- Integration with external formats (MOOSE, HDF5, CSV)

https://claude.ai/code/session_01GaN53R1Lah6mHsufVrAKgK